### PR TITLE
refactor: rename adr agent to architect and add decision records

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -1,5 +1,5 @@
 ---
-name: adr
+name: architect
 description: "Commit architectural decisions by creating ADRs and core-components, and update the decision registry."
 tools:
   - search/codebase
@@ -26,6 +26,13 @@ You MUST read all existing core-components under docs/architecture/core-componen
 You MUST NOT create an architectural decision outside of an ADR document.
 You MUST NOT create reusable cross-cutting behavior outside of a core-component document.
 You MUST update docs/architecture/ADR/DECISION-LOG.md for every ADR or core-component change.
+You MUST record one or more decision records in the Decisions section of DECISION-LOG.md for every ADR or core-component created.
+You MUST write each decision record as a short actionable statement that can be understood without opening the source document.
+You MUST derive decision records from the concrete choices made in an ADR — each chosen option, technology, pattern, or constraint is a separate decision.
+You MUST derive decision records from core-components by extracting each enforceable rule or behavioral contract.
+You MUST start each decision statement with an imperative verb (e.g. "Use", "Require", "Enforce", "Adopt", "Prohibit").
+You MUST NOT write vague or aspirational decisions — every record must be specific enough to verify in a code review.
+You MUST reference the source as the ADR or core-component ID (e.g. ADR-0002, CORE-COMPONENT-0003).
 You MUST treat ADRs and core-components as global artifacts not scoped to any workitem.
 You MUST create a Plan of Attack at docs/workitems/<WI-ID>/plan/01-action-plan.md for each workitem.
 You MUST follow the ADR template structure exactly when creating new ADRs.
@@ -43,6 +50,41 @@ ADR_DIR: "docs/architecture/ADR"
 CORE_COMPONENT_DIR: "docs/architecture/core-components"
 ADR_PATTERN: "ADR-####-slug.md"
 CORE_COMPONENT_PATTERN: "CORE-COMPONENT-####-slug.md"
+DECISION_GUIDANCE: TEXT<<
+Purpose:
+  The Decisions section is the central quick-reference for every concrete commitment
+  made in the project. An agent or human reading only this table should know exactly
+  what was decided, without opening any ADR or core-component.
+
+Deriving decisions from an ADR:
+  - Extract each chosen option or technology (1 decision per choice).
+  - Extract each rejected alternative only if the rejection itself is a rule ("Prohibit ORM X").
+  - Extract constraints introduced ("Limit request payload to 1 MB").
+  - One ADR typically yields 1-4 decisions; never zero.
+
+Deriving decisions from a core-component:
+  - Extract each enforceable behavioral rule ("Require structured JSON logging on every service").
+  - Extract each integration contract ("Authenticate all API calls via JWT bearer tokens").
+  - One core-component typically yields 1-3 decisions; never zero.
+
+Writing style:
+  - Start with an imperative verb: Use, Require, Enforce, Adopt, Prohibit, Limit, Expose, etc.
+  - Max ~15 words — just enough to be unambiguous.
+  - No jargon without context ("Use Zod" is too vague; "Use Zod for runtime input validation" is good).
+  - Must be verifiable: could a reviewer check this in a PR? If not, rewrite.
+
+Good examples:
+  - "Use Next.js App Router for all page routing" (ADR-0002)
+  - "Adopt PostgreSQL as the primary data store" (ADR-0002)
+  - "Require all API handlers to validate input with Zod schemas" (CORE-COMPONENT-0003)
+  - "Enforce Conventional Commits on every commit message" (CORE-COMPONENT-0004)
+  - "Prohibit direct database access outside the repository layer" (ADR-0005)
+
+Bad examples (do NOT write these):
+  - "We decided on a tech stack" — too vague, not actionable.
+  - "Follow best practices for testing" — not specific, not verifiable.
+  - "Consider using Redis" — aspirational, not a commitment.
+>>
 </constants>
 
 <formats>
@@ -52,6 +94,15 @@ WHERE:
 - <ADR_ID> is String.
 - <ADR_TITLE> is String.
 - <STATUS> is String.
+- <DATE> is ISO8601.
+</format>
+
+<format id="DECISION_RECORD" name="Decision Record" purpose="Short actionable statement appended to the Decisions section of DECISION-LOG.md. Multiple records may derive from a single ADR or core-component.">
+| <SEQ> | <DECISION_STATEMENT> | <SOURCE_ID> | <DATE> |
+WHERE:
+- <SEQ> is Integer (sequential, auto-incremented across all decisions).
+- <DECISION_STATEMENT> is String (short imperative statement, e.g. "Use Express for HTTP routing").
+- <SOURCE_ID> is String (ADR-#### or CORE-COMPONENT-####).
 - <DATE> is ISO8601.
 </format>
 
@@ -87,20 +138,21 @@ NEXT_ADR_NUMBER: 0
 NEXT_CORE_COMPONENT_NUMBER: 0
 CREATED_ADRS: []
 CREATED_CORE_COMPONENTS: []
+CREATED_DECISIONS: []
 </runtime>
 
 <triggers>
-<trigger event="user_message" target="adr-router" />
+<trigger event="user_message" target="architect-router" />
 </triggers>
 
 <processes>
-<process id="adr-router" name="Route ADR request">
+<process id="architect-router" name="Route ADR request">
 IF CURRENT_WI_ID is empty:
   RUN `load-context`
 RUN `create-artifacts`
 RUN `update-decision-log`
 RUN `create-action-plan`
-RETURN: CREATED_ADRS, CREATED_CORE_COMPONENTS
+RETURN: CREATED_ADRS, CREATED_CORE_COMPONENTS, CREATED_DECISIONS
 </process>
 
 <process id="load-context" name="Load research brief and existing artifacts">
@@ -129,13 +181,16 @@ SET CORE_COMPONENT_CONTENT := <CONTENT> (from "Agent Inference" using RESEARCH_B
 IF CORE_COMPONENT_CONTENT is not empty:
   USE `edit/createDirectory` where: dirPath=CORE_COMPONENT_DIR
   USE `edit/createFile` where: content=CORE_COMPONENT_CONTENT, filePath="<CORE_COMPONENT_FILE_PATH>"
+SET CREATED_DECISIONS := <DECISIONS> (from "Agent Inference" — derive one or more short actionable statements per ADR/core-component created)
 </process>
 
 <process id="update-decision-log" name="Update the decision log with new entries">
 USE `read/readFile` where: filePath=DECISION_LOG_PATH
 CAPTURE CURRENT_LOG from `read/readFile`
-SET UPDATED_LOG := <LOG> (from "Agent Inference" using CURRENT_LOG, CREATED_ADRS, CREATED_CORE_COMPONENTS)
+SET UPDATED_LOG := <LOG> (from "Agent Inference" using CURRENT_LOG, CREATED_ADRS, CREATED_CORE_COMPONENTS, CREATED_DECISIONS)
 USE `edit/editFiles` where: filePath=DECISION_LOG_PATH
+NOTE: Append ADR rows to the ADRs table, core-component rows to the Core-Components table, and decision records to the Decisions table.
+NOTE: Each ADR or core-component MUST produce at least one decision record as a short actionable statement.
 </process>
 
 <process id="create-action-plan" name="Create the action plan for the workitem">

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ PIPELINE_STAGES: YAML<<
   purpose: Explore the problem space, classify scope, produce a research brief
 - id: architect
   name: Architect
-  agent: adr
+  agent: architect
   purpose: Commit decisions via ADRs and core-components, produce an action plan
 - id: plan
   name: Plan
@@ -75,6 +75,7 @@ bootstrap:
     - must create an ADR for the tech stack decision
     - must create a core-component file for each declared cross-cutting concern
     - must update DECISION-LOG.md with all new ADRs and core-components
+    - must record decision records in the Decisions section of DECISION-LOG.md for every ADR and core-component created
     - must not set up CI/CD pipelines or infrastructure
     - must not make feature-level decisions
 research:
@@ -100,8 +101,8 @@ research:
     - explicitly state if ADRs or core-components are required
     - propose ADR titles and core-component titles when applicable
     - never make architectural decisions — only propose them
-adr:
-  file: .github/agents/adr.agent.md
+architect:
+  file: .github/agents/architect.agent.md
   purpose: Commit architectural decisions by creating ADRs and core-components, and update the decision registry.
   tools:
     - file creation and editing
@@ -125,6 +126,8 @@ adr:
     - no architectural decision exists unless it is in an ADR
     - no reusable cross-cutting behavior exists unless it is a core-component
     - every ADR or core-component change must update DECISION-LOG.md
+    - every ADR or core-component must produce at least one decision record in the Decisions section of DECISION-LOG.md
+    - decision records are short actionable statements referencing their source ADR or core-component
     - ADRs and core-components are global — not scoped to a workitem
     - must create a Plan of Attack (01-action-plan.md) for the workitem
 planner:
@@ -249,9 +252,10 @@ SET WI_ID := <ID> (from "research")
 </process>
 
 <process id="architect" name="Architect stage">
-SET ADRS := <ADR_LIST> (from "adr" using WI_ID, SCOPE_TYPE)
-SET CORE_COMPONENTS := <CC_LIST> (from "adr" using WI_ID, SCOPE_TYPE)
-SET ACTION_PLAN := <PLAN> (from "adr" using WI_ID)
+SET ADRS := <ADR_LIST> (from "architect" using WI_ID, SCOPE_TYPE)
+SET CORE_COMPONENTS := <CC_LIST> (from "architect" using WI_ID, SCOPE_TYPE)
+SET DECISIONS := <DECISION_LIST> (from "architect" using ADRS, CORE_COMPONENTS)
+SET ACTION_PLAN := <PLAN> (from "architect" using WI_ID)
 </process>
 
 <process id="plan" name="Plan stage">

--- a/LLM.txt
+++ b/LLM.txt
@@ -3,7 +3,7 @@ CONTRIBUTING.md                                             — Human contributi
 LLM.txt                                                     — This file; repo map for AI agents
 README.md                                                   — Project overview
 .devcontainer/devcontainer.json                             — Dev container configuration
-.github/agents/adr.agent.md                           — Architect agent (ADRs, core-components, action plans)
+.github/agents/architect.agent.md                      — Architect agent (ADRs, core-components, action plans)
 .github/agents/aps-v1.1.11.agent.md                         — APS prompt generator agent
 .github/agents/excali.agent.md                              — Excalidraw diagram agent
 .github/agents/implementer.agent.md                   — Implementer agent (code, tests, verification)

--- a/docs/architecture/ADR/DECISION-LOG.md
+++ b/docs/architecture/ADR/DECISION-LOG.md
@@ -13,3 +13,11 @@ This file is the single registry of all architectural decisions and core-compone
 | ID | Title | Status | Date |
 |----|-------|--------|------|
 | _No core-components yet. Copy `CORE-COMPONENT-0001-template.md` from `../core-components/` and rename it._ | | | |
+
+## Decisions
+
+Short, actionable statements derived from ADRs and core-components. More than one decision can originate from a single source.
+
+| # | Decision | Source | Date |
+|---|----------|--------|------|
+| _No decisions yet._ | | | |


### PR DESCRIPTION
## Summary

Port upstream updates from jsburckhardt/soft-factory#3 to rename the ADR agent to Architect and add decision record capabilities.

## Changes

1. **`.github/agents/adr.agent.md` → `architect.agent.md`** — Renamed agent, added `DECISION_GUIDANCE` constant, `DECISION_RECORD` format, `CREATED_DECISIONS` runtime state, and decision record guardrails
2. **`AGENTS.md`** — Updated agent references from `adr` to `architect`, added decision record guardrails to bootstrap and architect agents, added `DECISIONS` output to architect process
3. **`LLM.txt`** — Updated file reference
4. **`docs/architecture/ADR/DECISION-LOG.md`** — Added new `## Decisions` section with table template

## Type

- [x] Documentation
- [x] Agent configuration
- [x] Refactor

## Commit

- 5ca0e24 - refactor: rename adr agent to architect and add decision records