### PR TITLE
chore(tui): improve save UX with dirty tracking, post-save reload, and enter-to-confirm

### DIFF
--- a/docs/architecture/ADR/DECISION-LOG.md
+++ b/docs/architecture/ADR/DECISION-LOG.md
@@ -47,3 +47,6 @@ Short, actionable statements derived from ADRs and core-components. More than on
 | 20 | Show view-specific key hints in the help bar per state | ADR-0004 | 2026-02-20 |
 | 21 | Auto-detect env var metadata by running `copilot help environment` at startup | ADR-0004 | 2026-02-20 |
 | 22 | Mask sensitive env var values (COPILOT_GITHUB_TOKEN, GH_TOKEN, GITHUB_TOKEN) using CC-0005 patterns | ADR-0004 | 2026-02-20 |
+| 23 | Track per-field dirty state via `Modified` flag on `ConfigItem` | CC-0004 | 2026-02-21 |
+| 24 | Re-read config from disk after every successful save to verify round-trip integrity | CC-0004 | 2026-02-21 |
+| 25 | Clear "✓ Saved" indicator when any new in-memory change is committed | CC-0004 | 2026-02-21 |

--- a/docs/architecture/core-components/CORE-COMPONENT-0004-configuration-management.md
+++ b/docs/architecture/core-components/CORE-COMPONENT-0004-configuration-management.md
@@ -21,6 +21,9 @@ The `internal/config` package. Affects how the TUI presents config fields and ho
 - The installed copilot version is detected by running `copilot version` and parsing the output
 - When writing config, only known editable fields are updated; sensitive, token-like, and unknown fields are preserved unchanged and displayed as read-only in the TUI
 - Config validation occurs before writing — invalid values are rejected with user-friendly errors
+- The TUI must track per-field dirty state (`Modified` flag) for in-memory changes that have not yet been persisted to disk, and surface this to the user via a "(not-saved)" indicator
+- After a successful `SaveConfig`, the TUI must re-read the config file from disk via `LoadConfig` to verify round-trip integrity and reflect the actual persisted state
+- The "✓ Saved" UI indicator must be cleared immediately when any new in-memory change is committed, so the banner never shows stale information
 
 ### Interfaces
 - `Config` struct holds typed known fields plus a raw `map[string]any` for round-tripping
@@ -67,6 +70,9 @@ err = config.SaveConfig(config.DefaultPath(), cfg)
 - The TUI layer calls `Config.Set()` to update values
 - On form submission, call `SaveConfig()` to persist
 - Always load schema before presenting the form so field metadata is available
+- After `SaveConfig()` succeeds, call `LoadConfig()` and rebuild list entries from the reloaded config to verify the round-trip
+- Mark fields as modified when `Config.Set()` is called from the TUI; clear all modified markers after a successful save-and-reload cycle
+- If post-save `LoadConfig()` fails, show a non-fatal error in the UI header and keep the in-memory state
 
 ## Exceptions
 

--- a/docs/workitems/WI-0006-user-experience-saving/01-action-plan.md
+++ b/docs/workitems/WI-0006-user-experience-saving/01-action-plan.md
@@ -1,0 +1,197 @@
+# Action Plan: User Experience — Saving and Viewing Configuration Values
+
+> **Note:** This file should be at `plan/01-action-plan.md` once the `plan/` directory is created.
+
+## Feature
+- **ID:** WI-0006-user-experience-saving
+- **Research Brief:** [00-research.md](research/00-research.md)
+
+## ADRs Created
+None — all changes are within the existing two-panel layout pattern established by [ADR-0003](../../architecture/ADR/ADR-0003-two-panel-tui-layout.md). The state machine gains a new transition (`Enter` → commit for non-`list` types) but the Browsing/Editing duality is unchanged.
+
+## Core-Components Updated
+**CORE-COMPONENT-0004 (Configuration Management)** was **updated** to document:
+1. Per-field dirty tracking via `Modified` flag on `ConfigItem`
+2. Post-save reload requirement (re-read from disk after `SaveConfig` via `LoadConfig`)
+3. Rule that "✓ Saved" indicator must be cleared on new in-memory commits
+
+See: [CORE-COMPONENT-0004-configuration-management.md](../../architecture/core-components/CORE-COMPONENT-0004-configuration-management.md)
+
+## Core-Components Created
+None.
+
+## Applicable Existing Decisions
+| Source | Decision |
+|--------|----------|
+| ADR-0003 | Two-panel TUI layout with Browsing/Editing state machine |
+| CC-0004 (Decision 6) | Auto-detect config schema by running `copilot help config` at startup |
+| CC-0004 (Decision 7) | Preserve unknown config fields on round-trip (no data loss) |
+| CC-0004 (Decision 17) | Track per-field dirty state via `Modified` flag on `ConfigItem` |
+| CC-0004 (Decision 18) | Re-read config from disk after every successful save |
+| CC-0004 (Decision 19) | Clear "✓ Saved" indicator when any new in-memory change is committed |
+
+## Constraints & Boundaries
+
+- **Scope boundary**: All changes confined to `internal/tui/`. No changes to `internal/config/`, `internal/copilot/`, `internal/sensitive/`, or `cmd/`.
+- **No new dependencies**: All required packages (`bubbles/textinput`, `bubbles/textarea`, `lipgloss`, `bubbletea`, `config.LoadConfig`) are already available.
+- **`list` field exception**: `Enter` inside `textarea` (list type) is the correct UX for adding a new line. `Enter`-to-commit must be skipped for `list`-type fields. `Esc` remains the commit key for `list` fields.
+- **No validation**: Input validation before commit is out of scope.
+- **No auto-save**: Explicit save gesture (`Ctrl+S`) is retained as the persistence trigger.
+- **No undo/revert**: Out of scope for this workitem.
+
+## Implementation Tasks
+
+### Task 1: Extract commit helper function
+**File:** `internal/tui/model.go`
+
+**What:** Extract the existing `Esc` commit logic (lines 203–211) into a shared `commitAndReturnToBrowsing()` method on `Model`. This method performs:
+1. `newValue := m.detailPanel.StopEditing()`
+2. `m.cfg.Set(item.Field.Name, newValue)`
+3. `m.listPanel.UpdateItemValue(item.Field.Name, newValue)` — this also marks the field modified (see Task 3)
+4. `m.saved = false` *(clear stale saved indicator)*
+5. `m.err = nil`
+6. `m.state = StateBrowsing`
+
+**Why:** Eliminates duplication between `Enter` and `Esc` commit paths.
+
+### Task 2: Intercept Enter in StateEditing for non-list fields
+**File:** `internal/tui/model.go`
+
+**What:** In the `StateEditing` branch of `handleKeyPress`, add an `Enter` handler **before** the default forwarding to `detailPanel.Update()`:
+```
+case StateEditing:
+    if k == "esc" || (k == "enter" && currentFieldType != "list"):
+        commitAndReturnToBrowsing()
+    else:
+        forward to detailPanel.Update(msg)
+```
+Use `m.listPanel.SelectedItem().Field.Type` (or `m.detailPanel.CurrentFieldType()` accessor — see Task 8) to determine whether `Enter` should commit or be forwarded.
+
+**Why:** Fixes Gap G2 — `Enter` now commits the change and returns to browsing for `string`, `bool`, and `enum` fields.
+
+### Task 3: Add dirty tracking to ConfigItem and ListPanel
+**File:** `internal/tui/list_item.go`
+
+**What:**
+1. Add `Modified bool` field to `ConfigItem` struct
+2. In `UpdateItemValue()`, set `l.entries[i].item.Modified = true` when updating the value
+3. Add `ClearAllModified()` method that iterates all entries and sets `Modified = false`
+4. When rendering, append ` (not-saved)` to the display string when `item.Modified` is true
+5. Account for the `(not-saved)` suffix width (12 chars) when computing `valWidth` to avoid truncation of the actual value
+
+**Why:** Fixes Gap G3 — users see which fields have in-memory changes not yet written to disk.
+
+### Task 4: Pass Modified flag through renderItem
+**File:** `internal/tui/list_item.go`
+
+**What:** Update `renderItem()` to use `item.Modified` when computing the value display. Reduce `valWidth` by 12 characters when `item.Modified` is true so the actual value still fits alongside the `(not-saved)` suffix. Append the suffix after `formatValueCompact` returns.
+
+**Why:** Ensures the "(not-saved)" indicator renders correctly without truncating the value display.
+
+### Task 5: Post-save reload from disk
+**File:** `internal/tui/model.go`
+
+**What:** In the `ctrl+s` handler, after successful `SaveConfig`:
+1. Call `config.LoadConfig(m.configPath)` to re-read the file
+2. Replace `m.cfg` with the freshly loaded config
+3. Save the current cursor field name before rebuild
+4. Rebuild list entries: `entries := buildEntries(m.cfg, m.schema)`
+5. Create a new `ListPanel` with the rebuilt entries (or update entries in-place)
+6. Restore cursor to the same field name (by name, not index)
+7. Re-sync the detail panel via `m.syncDetailPanel()`
+8. Set `m.saved = true`
+9. Clear `m.err` on success
+
+**Failure path:** If `LoadConfig` fails after a successful `SaveConfig`, set `m.err` to a descriptive error (e.g., "saved but reload failed: ..."), keep the in-memory state, and still set `m.saved = true` (because the save itself succeeded).
+
+**Why:** Fixes Gap G5 — the UI reflects the actual persisted state after save.
+
+### Task 6: Clear saved flag on new edits
+**File:** `internal/tui/model.go`
+
+**What:** In the `commitAndReturnToBrowsing()` helper (Task 1), set `m.saved = false` and `m.err = nil`. This ensures the "✓ Saved" banner disappears the moment the user commits a new change.
+
+**Why:** Fixes Gap G6 — prevents stale "✓ Saved" banner.
+
+### Task 7: Clear all modified flags after save
+**File:** `internal/tui/model.go`
+
+**What:** After successful save-and-reload (Task 5), call `m.listPanel.ClearAllModified()` to remove all `(not-saved)` indicators. If reload fails but save succeeded, still clear modified flags (the data is on disk).
+
+**Why:** Fixes Gap G4 — `(not-saved)` indicators disappear after `Ctrl+S`.
+
+### Task 8: Expose CurrentFieldType accessor
+**File:** `internal/tui/detail_panel.go`
+
+**What:** Add a `CurrentFieldType() string` method to `DetailPanel`:
+```go
+func (d *DetailPanel) CurrentFieldType() string {
+    if d.field == nil {
+        return ""
+    }
+    return d.field.Type
+}
+```
+
+**Why:** Needed by Task 2 for field-type-aware `Enter` handling, and by Task 9 for context-aware help bar.
+
+### Task 9: Update help bar for editing state
+**Files:** `internal/tui/keys.go`, `internal/tui/model.go`
+
+**What:**
+1. Add a `Confirm key.Binding` to `KeyMap` with help text `"enter" / "confirm"`
+2. Update `ShortHelp(state State)` to accept a field type parameter (or add a `ShortHelpEditing(fieldType string)` variant)
+3. For `StateEditing`:
+   - Non-`list` fields: show `[enter • confirm]  [esc • confirm]  [ctrl+s • save]  [ctrl+c • quit]`
+   - `list` fields: show `[esc • done]  [ctrl+s • save]  [ctrl+c • quit]` (Enter = newline is implicit)
+4. Update `Model.View()` to pass the field type when constructing help keys
+
+**Why:** Users need clear guidance on how to commit their edit, especially the Enter vs Esc distinction for list fields.
+
+### Task 10: Add/update tests
+**File:** `internal/tui/tui_test.go`
+
+**What:** Add tests for all four fixed behaviours:
+
+| Test ID | Description |
+|---------|-------------|
+| UT-TUI-026 | `Enter` in `StateEditing` on `enum` field commits value and returns to `StateBrowsing` |
+| UT-TUI-027 | `Enter` in `StateEditing` on `string` field commits value and returns to `StateBrowsing` |
+| UT-TUI-028 | `Enter` in `StateEditing` on `bool` field commits value and returns to `StateBrowsing` |
+| UT-TUI-029 | `Enter` in `StateEditing` on `list` field does NOT exit editing (forwarded to textarea) |
+| UT-TUI-030 | `ConfigItem.Modified` is `false` by default and set to `true` after `UpdateItemValue` |
+| UT-TUI-031 | `formatValueCompact` appends `(not-saved)` when `Modified` is true |
+| UT-TUI-032 | `ClearAllModified` resets all `Modified` flags to false |
+| UT-TUI-033 | `m.saved` is cleared (`false`) after committing a new edit via Enter or Esc |
+| UT-TUI-034 | Help bar shows `enter • confirm` for non-list fields in editing state |
+| UT-TUI-035 | Help bar shows `esc • done` (no Enter confirm) for list fields in editing state |
+
+**Update existing test:**
+- UT-TUI-008: Extend to verify that `Esc` also clears `m.saved` and marks the field modified
+
+## Implementation Order
+
+```
+Task 3  (dirty tracking on ConfigItem/ListPanel)
+  └─► Task 4  (renderItem integration)
+Task 8  (CurrentFieldType accessor)
+  └─► Task 1  (extract commit helper)
+        ├─► Task 2  (Enter intercept — depends on Task 1 + Task 8)
+        └─► Task 6  (clear saved — integrated into Task 1)
+Task 5  (post-save reload)
+  └─► Task 7  (clear modified after save — depends on Task 3 + Task 5)
+Task 9  (help bar — depends on Task 8)
+Task 10 (tests — depends on all above)
+```
+
+Tasks 3 and 8 can be done in parallel as the first step. Tasks 1+2+6 form a logical unit. Tasks 5+7 form a logical unit. Task 9 is independent of the others. Task 10 is last.
+
+## Risk Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Cursor position lost after post-save reload | Restore cursor by field name (not index) after rebuilding entries |
+| `(not-saved)` suffix truncates values in narrow terminals | Reduce `valWidth` by 12 chars when `Modified` is true; test at 80-column |
+| `Enter` inside `textarea` is ambiguous for list fields | Explicitly skip Enter-commit for `list` type; document in help bar |
+| Post-save `LoadConfig` fails | Non-fatal error in header; keep in-memory state; still mark as saved |
+| Existing UT-TUI-008 test assumptions | Update test to also verify `m.saved` cleared and `Modified` set |

--- a/docs/workitems/WI-0006-user-experience-saving/02-task-breakdown.md
+++ b/docs/workitems/WI-0006-user-experience-saving/02-task-breakdown.md
@@ -1,0 +1,460 @@
+# Task Breakdown: WI-0006 — User Experience Saving and Viewing Configuration Values
+
+> **Note:** This file should be at `plan/02-task-breakdown.md` once the `plan/` directory is created.
+
+- **Workitem:** WI-0006-user-experience-saving
+- **Action Plan:** [01-action-plan.md](01-action-plan.md)
+- **Test Plan:** [03-test-plan.md](03-test-plan.md)
+
+## Summary
+
+This task breakdown decomposes the four UX bug fixes into 10 implementation tasks ordered by dependency. All changes are confined to `internal/tui/`. No new Go dependencies are required.
+
+### Bug → Task Mapping
+
+| Bug | Description | Fixing Tasks |
+|-----|-------------|--------------|
+| Bug 1 | Enter doesn't commit & exit editing | Task 8, Task 1, Task 2 |
+| Bug 2 | No "(not-saved)" indicator | Task 3, Task 4 |
+| Bug 3 | Config not re-read after Ctrl+S | Task 5 |
+| Bug 4 | "✓ Saved" banner shows stale info | Task 6, Task 7 |
+
+### Dependency Graph
+
+```
+Task 8  (CurrentFieldType accessor) ──────────┐
+Task 3  (dirty tracking) ─► Task 4 (render)   │
+                                               ▼
+                                     Task 1  (extract commit helper)
+                                       ├──► Task 2  (Enter intercept)
+                                       └──► Task 6  (clear saved — in Task 1)
+Task 5  (post-save reload)
+  └──► Task 7  (clear modified after save — depends on Task 3 + Task 5)
+Task 9  (help bar — depends on Task 8)
+Task 10 (tests — depends on all above)
+```
+
+---
+
+## Task 8: Expose CurrentFieldType accessor on DetailPanel
+
+- **Status:** Not Started
+- **Complexity:** XS (trivial — 5-line method)
+- **Dependencies:** None
+- **Related ADRs:** [ADR-0003](../../architecture/ADR/ADR-0003-two-panel-tui-layout.md)
+- **Related Core-Components:** [CC-0004](../../architecture/core-components/CORE-COMPONENT-0004-configuration-management.md)
+
+### Description
+
+Add a `CurrentFieldType() string` method to `DetailPanel` in `internal/tui/detail_panel.go`. This method returns `d.field.Type` when a field is loaded, or `""` when `d.field` is nil.
+
+```go
+func (d *DetailPanel) CurrentFieldType() string {
+    if d.field == nil {
+        return ""
+    }
+    return d.field.Type
+}
+```
+
+This accessor is needed by Task 2 (Enter intercept logic) and Task 9 (context-aware help bar).
+
+### Acceptance Criteria
+
+- [ ] `DetailPanel` has a public `CurrentFieldType() string` method
+- [ ] Returns `""` when no field is set (`d.field == nil`)
+- [ ] Returns the field's `.Type` string (`"string"`, `"bool"`, `"enum"`, `"list"`) when a field is set
+- [ ] No change to `DetailPanel.View()` or `DetailPanel.Update()` behaviour
+
+### Test Coverage
+
+- Unit test: `CurrentFieldType()` returns `""` on a fresh `DetailPanel` with no field set
+- Unit test: `CurrentFieldType()` returns correct type after `SetField()` is called for each type (`string`, `bool`, `enum`, `list`)
+
+---
+
+## Task 3: Add dirty tracking to ConfigItem and ListPanel
+
+- **Status:** Not Started
+- **Complexity:** S (struct change + 2 method changes)
+- **Dependencies:** None
+- **Related ADRs:** [ADR-0003](../../architecture/ADR/ADR-0003-two-panel-tui-layout.md)
+- **Related Core-Components:** [CC-0004](../../architecture/core-components/CORE-COMPONENT-0004-configuration-management.md) — Decision 17
+
+### Description
+
+Modify `internal/tui/list_item.go` to support per-field dirty state tracking:
+
+1. Add `Modified bool` field to the `ConfigItem` struct (after `Value any`)
+2. In `UpdateItemValue()`, set `l.entries[i].item.Modified = true` when the value is updated
+3. Add a new `ClearAllModified()` method on `ListPanel` that iterates all entries and sets `Modified = false`
+
+This implements Decision 17 from the Decision Log: "Track per-field dirty state via `Modified` flag on `ConfigItem`".
+
+### Acceptance Criteria
+
+- [ ] `ConfigItem` struct has a `Modified bool` field
+- [ ] `Modified` is `false` by default when entries are built via `buildEntries()`
+- [ ] `UpdateItemValue()` sets `Modified = true` on the matching entry
+- [ ] `ClearAllModified()` method exists on `ListPanel` and resets all `Modified` flags to `false`
+- [ ] Existing `SelectedItem()` returns a copy that includes the `Modified` field
+
+### Test Coverage
+
+- Unit test (UT-TUI-030): `ConfigItem.Modified` is `false` by default and set to `true` after `UpdateItemValue()`
+- Unit test (UT-TUI-032): `ClearAllModified()` resets all `Modified` flags to `false`
+
+---
+
+## Task 4: Render "(not-saved)" indicator in list panel
+
+- **Status:** Not Started
+- **Complexity:** S (rendering logic change)
+- **Dependencies:** Task 3
+- **Related ADRs:** [ADR-0003](../../architecture/ADR/ADR-0003-two-panel-tui-layout.md)
+- **Related Core-Components:** [CC-0004](../../architecture/core-components/CORE-COMPONENT-0004-configuration-management.md) — Decision 17
+
+### Description
+
+Update `renderItem()` and/or `formatValueCompact()` in `internal/tui/list_item.go` to display a `(not-saved)` suffix when `item.Modified` is `true`.
+
+Implementation details:
+1. In `renderItem()`, when `item.Modified` is `true`, reduce `valWidth` by 12 characters (`len(" (not-saved)")`) before calling `formatValueCompact()`, so the actual value still fits alongside the suffix
+2. After `formatValueCompact()` returns, append ` (not-saved)` to the value string when `Modified` is `true`
+3. Ensure `valWidth` floor check (`if valWidth < 3`) still applies after the reduction
+4. Test at 80-column terminal width to ensure no truncation issues
+
+### Acceptance Criteria
+
+- [ ] When `item.Modified == true`, the list row displays the value followed by ` (not-saved)`
+- [ ] When `item.Modified == false`, the list row displays the value without any suffix (no change from current behaviour)
+- [ ] The `(not-saved)` suffix does not cause the actual value to be truncated — `valWidth` is reduced to accommodate the suffix
+- [ ] At 80-column terminal width, items with `(not-saved)` render without visual overflow or clipping
+- [ ] `formatValueCompact()` function signature is unchanged (the suffix is appended in `renderItem()`, not in `formatValueCompact()`)
+
+### Test Coverage
+
+- Unit test (UT-TUI-031): `renderItem` appends `(not-saved)` when `Modified` is `true`
+- Unit test: `renderItem` does NOT append `(not-saved)` when `Modified` is `false`
+- Unit test: at narrow width (e.g., `width=30`), `(not-saved)` suffix and value both render without panic
+
+---
+
+## Task 1: Extract commitAndReturnToBrowsing helper function
+
+- **Status:** Not Started
+- **Complexity:** S (refactor — extract existing code into method)
+- **Dependencies:** Task 8
+- **Related ADRs:** [ADR-0003](../../architecture/ADR/ADR-0003-two-panel-tui-layout.md)
+- **Related Core-Components:** [CC-0004](../../architecture/core-components/CORE-COMPONENT-0004-configuration-management.md) — Decision 19
+
+### Description
+
+Extract the existing `Esc` commit logic (lines 203–211 of `internal/tui/model.go`) into a shared `commitAndReturnToBrowsing()` method on `*Model`. This method performs:
+
+1. `newValue := m.detailPanel.StopEditing()`
+2. Gets the selected item via `m.listPanel.SelectedItem()`
+3. `m.cfg.Set(item.Field.Name, newValue)` — updates in-memory config
+4. `m.listPanel.UpdateItemValue(item.Field.Name, newValue)` — updates list display (this also marks the field `Modified` per Task 3)
+5. `m.saved = false` — clears stale saved indicator (Task 6 requirement)
+6. `m.err = nil` — clears any stale error
+7. `m.state = StateBrowsing` — returns to browsing state
+
+The existing `Esc` branch in `handleKeyPress` is then simplified to call `m.commitAndReturnToBrowsing()`.
+
+### Acceptance Criteria
+
+- [ ] A `commitAndReturnToBrowsing()` method exists on `*Model`
+- [ ] The `Esc` key handling in `StateEditing` calls `commitAndReturnToBrowsing()` instead of inline logic
+- [ ] Existing behaviour is preserved: `Esc` in editing mode still commits the value, updates the list, and returns to `StateBrowsing`
+- [ ] `m.saved` is set to `false` inside `commitAndReturnToBrowsing()` (Task 6 requirement)
+- [ ] `m.err` is set to `nil` inside `commitAndReturnToBrowsing()`
+- [ ] No change in user-visible behaviour for the `Esc` path (regression safety)
+
+### Test Coverage
+
+- Existing test UT-TUI-008 must continue to pass (Esc transitions from Editing to Browsing)
+- Unit test (UT-TUI-033): After calling `commitAndReturnToBrowsing()`, `m.saved == false`
+- Unit test: After calling `commitAndReturnToBrowsing()`, `m.err == nil`
+
+---
+
+## Task 6: Clear saved flag on new edits
+
+- **Status:** Not Started
+- **Complexity:** XS (single line — integrated into Task 1)
+- **Dependencies:** Task 1
+- **Related ADRs:** [ADR-0003](../../architecture/ADR/ADR-0003-two-panel-tui-layout.md)
+- **Related Core-Components:** [CC-0004](../../architecture/core-components/CORE-COMPONENT-0004-configuration-management.md) — Decision 19
+
+### Description
+
+This task is logically integrated into Task 1. The `commitAndReturnToBrowsing()` helper sets `m.saved = false` and `m.err = nil`. This ensures the "✓ Saved" banner disappears the moment the user commits a new change.
+
+The implementation is a single line (`m.saved = false`) inside the helper created in Task 1. This task exists as a separate logical concern for traceability to Bug 4 and Decision 19.
+
+### Acceptance Criteria
+
+- [ ] When `m.saved == true` (i.e., after a previous `Ctrl+S`), committing a new change (via Enter or Esc) sets `m.saved = false`
+- [ ] The "✓ Saved" banner in `View()` no longer appears after a new change is committed
+- [ ] `m.err` is cleared to `nil` after a commit
+
+### Test Coverage
+
+- Unit test (UT-TUI-033): `m.saved` is `false` after committing a new edit via Enter or Esc, even when it was `true` before the commit
+- Extends UT-TUI-008: Verify that `m.saved` is cleared after Esc-commit
+
+---
+
+## Task 2: Intercept Enter in StateEditing for non-list fields
+
+- **Status:** Not Started
+- **Complexity:** S (conditional branch + field-type check)
+- **Dependencies:** Task 1, Task 8
+- **Related ADRs:** [ADR-0003](../../architecture/ADR/ADR-0003-two-panel-tui-layout.md)
+- **Related Core-Components:** [CC-0004](../../architecture/core-components/CORE-COMPONENT-0004-configuration-management.md)
+
+### Description
+
+In the `StateEditing` branch of `handleKeyPress` in `internal/tui/model.go`, add an `Enter` handler **before** the default forwarding to `detailPanel.Update()`:
+
+```go
+case StateEditing:
+    if k == "esc" || (k == "enter" && m.detailPanel.CurrentFieldType() != "list") {
+        m.commitAndReturnToBrowsing()
+        return m, nil
+    }
+    // All other keys go to detail panel
+    return m, m.detailPanel.Update(msg)
+```
+
+Key behavioural rules:
+- For `string`, `bool`, `enum` field types: `Enter` commits the value and returns to `StateBrowsing`
+- For `list` field type: `Enter` is forwarded to the `textarea` widget (inserts a newline) — `Esc` remains the only commit key for lists
+- `Esc` continues to commit for ALL field types (including `list`)
+
+Uses `m.detailPanel.CurrentFieldType()` (from Task 8) to determine the field type.
+
+### Acceptance Criteria
+
+- [ ] `Enter` in `StateEditing` on `enum` fields commits the value and returns to `StateBrowsing`
+- [ ] `Enter` in `StateEditing` on `string` fields commits the value and returns to `StateBrowsing`
+- [ ] `Enter` in `StateEditing` on `bool` fields commits the value and returns to `StateBrowsing`
+- [ ] `Enter` in `StateEditing` on `list` fields does NOT exit editing — the key is forwarded to `textarea`
+- [ ] `Esc` still commits and exits for ALL field types (including `list`)
+- [ ] The committed value is correctly stored in `m.cfg` and reflected in the list panel
+
+### Test Coverage
+
+- Unit test (UT-TUI-026): `Enter` on `enum` field commits value and returns to `StateBrowsing`
+- Unit test (UT-TUI-027): `Enter` on `string` field commits value and returns to `StateBrowsing`
+- Unit test (UT-TUI-028): `Enter` on `bool` field commits value and returns to `StateBrowsing`
+- Unit test (UT-TUI-029): `Enter` on `list` field does NOT exit editing (stays in `StateEditing`)
+
+---
+
+## Task 5: Post-save reload from disk
+
+- **Status:** Not Started
+- **Complexity:** M (reload + rebuild + cursor restoration)
+- **Dependencies:** None (can be developed in parallel with Tasks 1-4, but must be integrated after Task 3 for Task 7)
+- **Related ADRs:** [ADR-0003](../../architecture/ADR/ADR-0003-two-panel-tui-layout.md)
+- **Related Core-Components:** [CC-0004](../../architecture/core-components/CORE-COMPONENT-0004-configuration-management.md) — Decision 18
+
+### Description
+
+In the `ctrl+s` handler in `internal/tui/model.go`, after a successful `SaveConfig`, reload the config from disk to verify round-trip integrity:
+
+```go
+if k == "ctrl+s" {
+    if err := config.SaveConfig(m.configPath, m.cfg); err != nil {
+        m.err = err
+        slog.Error("save failed", "error", err)
+    } else {
+        // Post-save reload
+        reloaded, reloadErr := config.LoadConfig(m.configPath)
+        if reloadErr != nil {
+            m.err = fmt.Errorf("saved but reload failed: %w", reloadErr)
+            slog.Error("post-save reload failed", "error", reloadErr)
+        } else {
+            // Save cursor position by field name
+            cursorFieldName := ""
+            if item := m.listPanel.SelectedItem(); item != nil {
+                cursorFieldName = item.Field.Name
+            }
+
+            // Replace config and rebuild
+            m.cfg = reloaded
+            entries := buildEntries(m.cfg, m.schema)
+            m.listPanel = NewListPanel(entries)
+
+            // Restore cursor by name
+            m.restoreCursorByName(cursorFieldName)
+
+            m.err = nil
+        }
+        m.saved = true
+        m.syncDetailPanel()
+    }
+    return m, nil
+}
+```
+
+A helper method `restoreCursorByName(name string)` on `*Model` (or on `*ListPanel`) scans entries by field name and sets the cursor position.
+
+**Failure path**: If `LoadConfig` fails after a successful `SaveConfig`, set `m.err` to a descriptive error, keep the in-memory state, and still set `m.saved = true` (because the save itself succeeded).
+
+### Acceptance Criteria
+
+- [ ] After `Ctrl+S`, `config.LoadConfig(m.configPath)` is called
+- [ ] On successful reload: `m.cfg` is replaced with the reloaded config
+- [ ] On successful reload: list entries are rebuilt from the reloaded config via `buildEntries()`
+- [ ] On successful reload: cursor is restored to the same field (by name, not index)
+- [ ] On successful reload: detail panel is re-synced via `syncDetailPanel()`
+- [ ] On successful reload: `m.saved = true` and `m.err = nil`
+- [ ] On reload failure: `m.err` is set to `"saved but reload failed: <error>"`
+- [ ] On reload failure: `m.saved = true` (save succeeded), in-memory state is preserved
+- [ ] On save failure: existing behaviour preserved — `m.err` is set, `m.saved` is NOT set to `true`
+
+### Test Coverage
+
+- Unit test: After a successful save+reload cycle, `m.cfg` reflects the persisted state
+- Unit test: Cursor position is preserved (by field name) after save+reload
+- Unit test: Detail panel is synced to the correct field after save+reload
+- Integration-style test: Save followed by reload produces a round-trip-consistent config
+- Unit test: If post-save reload fails, `m.saved == true` and `m.err` contains "reload failed"
+
+---
+
+## Task 7: Clear all modified flags after save
+
+- **Status:** Not Started
+- **Complexity:** XS (single method call after save)
+- **Dependencies:** Task 3, Task 5
+- **Related ADRs:** [ADR-0003](../../architecture/ADR/ADR-0003-two-panel-tui-layout.md)
+- **Related Core-Components:** [CC-0004](../../architecture/core-components/CORE-COMPONENT-0004-configuration-management.md) — Decision 17
+
+### Description
+
+After a successful save-and-reload (Task 5), call `m.listPanel.ClearAllModified()` (from Task 3) to remove all `(not-saved)` indicators. If reload fails but save succeeded, still clear modified flags (the data is on disk).
+
+The call should be placed after `m.saved = true` in the `ctrl+s` handler, so it runs regardless of whether reload succeeded or failed (as long as save succeeded).
+
+### Acceptance Criteria
+
+- [ ] After a successful `Ctrl+S`, all `(not-saved)` indicators are removed from the list panel
+- [ ] `ClearAllModified()` is called after successful save, even if reload fails
+- [ ] `ClearAllModified()` is NOT called if the save itself fails
+- [ ] After clearing, subsequent `View()` calls render items without `(not-saved)` suffix
+
+### Test Coverage
+
+- Unit test: After save, `listPanel` entries all have `Modified == false`
+- Unit test: If save fails, `Modified` flags remain unchanged
+
+---
+
+## Task 9: Update help bar for editing state
+
+- **Status:** Not Started
+- **Complexity:** S (keybinding + conditional rendering)
+- **Dependencies:** Task 8
+- **Related ADRs:** [ADR-0003](../../architecture/ADR/ADR-0003-two-panel-tui-layout.md)
+- **Related Core-Components:** [CC-0004](../../architecture/core-components/CORE-COMPONENT-0004-configuration-management.md)
+
+### Description
+
+Update `internal/tui/keys.go` and `internal/tui/model.go` to show context-aware help text in the editing state:
+
+1. **keys.go**: Add a `Confirm key.Binding` to `KeyMap` with `key.WithKeys("enter")` and `key.WithHelp("enter", "confirm")`
+
+2. **model.go — `ShortHelp` method**: Update to accept field type information. Two approaches (choose one):
+   - Option A: Change signature to `ShortHelp(state State, fieldType string)`
+   - Option B: Add a `ShortHelpEditing(fieldType string) []key.Binding` variant
+
+   For `StateEditing`:
+   - Non-`list` fields: return `[Confirm, Escape, Save, Quit]` → renders as `enter • confirm  •  esc • done  •  ctrl+s • save  •  ctrl+c • quit`
+   - `list` fields: return `[Escape, Save, Quit]` → renders as `esc • done  •  ctrl+s • save  •  ctrl+c • quit` (Enter = newline is implicit for textarea)
+
+3. **model.go — `View` method**: Pass the current field type to `ShortHelp` when constructing help keys. Use `m.detailPanel.CurrentFieldType()` (from Task 8).
+
+### Acceptance Criteria
+
+- [ ] A `Confirm key.Binding` exists in `KeyMap` with help text `"enter" / "confirm"`
+- [ ] In `StateEditing` for non-`list` fields, help bar shows `enter • confirm` alongside `esc • done`
+- [ ] In `StateEditing` for `list` fields, help bar shows `esc • done` but NOT `enter • confirm`
+- [ ] In `StateBrowsing`, help bar is unchanged from current behaviour
+- [ ] Help bar renders correctly at 80-column width without truncation
+
+### Test Coverage
+
+- Unit test (UT-TUI-034): Help bar includes `enter • confirm` for non-list fields in editing state
+- Unit test (UT-TUI-035): Help bar does NOT include `enter • confirm` for list fields in editing state
+- Unit test: Help bar in browsing state is unchanged
+
+---
+
+## Task 10: Add and update unit tests
+
+- **Status:** Not Started
+- **Complexity:** M (10+ new test functions, 1 test update)
+- **Dependencies:** All previous tasks (1-9)
+- **Related ADRs:** [ADR-0002](../../architecture/ADR/ADR-0002-go-charm-tui-stack.md) (Decision 3 — use `go test`), [ADR-0003](../../architecture/ADR/ADR-0003-two-panel-tui-layout.md)
+- **Related Core-Components:** [CC-0004](../../architecture/core-components/CORE-COMPONENT-0004-configuration-management.md) — Decisions 17, 18, 19
+
+### Description
+
+Add tests to `internal/tui/tui_test.go` for all four fixed behaviours. Each test should follow the existing test patterns (create `config.NewConfig()`, build schema, construct model, simulate key presses, assert state).
+
+**New tests:**
+
+| Test ID | Description | Verifying Task |
+|---------|-------------|----------------|
+| UT-TUI-026 | `Enter` in `StateEditing` on `enum` field commits and returns to `StateBrowsing` | Task 2 |
+| UT-TUI-027 | `Enter` in `StateEditing` on `string` field commits and returns to `StateBrowsing` | Task 2 |
+| UT-TUI-028 | `Enter` in `StateEditing` on `bool` field commits and returns to `StateBrowsing` | Task 2 |
+| UT-TUI-029 | `Enter` in `StateEditing` on `list` field does NOT exit editing | Task 2 |
+| UT-TUI-030 | `ConfigItem.Modified` is `false` by default, `true` after `UpdateItemValue` | Task 3 |
+| UT-TUI-031 | `renderItem` appends `(not-saved)` when `Modified` is `true` | Task 4 |
+| UT-TUI-032 | `ClearAllModified()` resets all `Modified` flags to `false` | Task 3 |
+| UT-TUI-033 | `m.saved` is cleared (`false`) after committing a new edit via Enter or Esc | Task 1/6 |
+| UT-TUI-034 | Help bar shows `enter • confirm` for non-list fields in editing state | Task 9 |
+| UT-TUI-035 | Help bar shows `esc • done` (no Enter confirm) for list fields in editing state | Task 9 |
+
+**Updated test:**
+
+| Test ID | Change | Verifying Task |
+|---------|--------|----------------|
+| UT-TUI-008 | Extend to verify `m.saved` is cleared and `Modified` is set after Esc commit | Tasks 1, 3, 6 |
+
+### Acceptance Criteria
+
+- [ ] All 10 new test functions are added to `internal/tui/tui_test.go`
+- [ ] UT-TUI-008 is extended with additional assertions
+- [ ] All tests pass with `go test ./internal/tui/...`
+- [ ] No existing tests are broken
+- [ ] Tests follow the naming convention `TestXxx` and include the UT-TUI-NNN identifier in a comment
+- [ ] Each test is self-contained (creates its own model, schema, config)
+
+### Test Coverage
+
+- Self-referential: This task IS the test coverage for all other tasks
+- Regression: All existing 25 tests (UT-TUI-001 through UT-TUI-025) must continue to pass
+- Coverage target: All four bug-fix behaviours have at least one dedicated test
+
+---
+
+## Implementation Checklist
+
+| Order | Task | Complexity | Dependencies | Status |
+|-------|------|-----------|--------------|--------|
+| 1 | Task 8: CurrentFieldType accessor | XS | None | Not Started |
+| 2 | Task 3: Dirty tracking on ConfigItem | S | None | Not Started |
+| 3 | Task 4: Render "(not-saved)" indicator | S | Task 3 | Not Started |
+| 4 | Task 1: Extract commit helper | S | Task 8 | Not Started |
+| 5 | Task 6: Clear saved flag (in Task 1) | XS | Task 1 | Not Started |
+| 6 | Task 2: Intercept Enter for non-list | S | Task 1, Task 8 | Not Started |
+| 7 | Task 5: Post-save reload from disk | M | None | Not Started |
+| 8 | Task 7: Clear modified after save | XS | Task 3, Task 5 | Not Started |
+| 9 | Task 9: Update help bar | S | Task 8 | Not Started |
+| 10 | Task 10: Add/update tests | M | All above | Not Started |

--- a/docs/workitems/WI-0006-user-experience-saving/03-test-plan.md
+++ b/docs/workitems/WI-0006-user-experience-saving/03-test-plan.md
@@ -1,0 +1,496 @@
+# Test Plan: WI-0006 — User Experience Saving and Viewing Configuration Values
+
+> **Note:** This file should be at `plan/03-test-plan.md` once the `plan/` directory is created.
+
+- **Workitem:** WI-0006-user-experience-saving
+- **Action Plan:** [01-action-plan.md](01-action-plan.md)
+- **Task Breakdown:** [02-task-breakdown.md](02-task-breakdown.md)
+
+## Overview
+
+All tests are unit tests in `internal/tui/tui_test.go` using `go test`. No integration tests against external binaries are required — the config `LoadConfig`/`SaveConfig` round-trip uses temp files. All tests follow the existing pattern: construct `config.NewConfig()`, define a schema, build a `Model`, simulate key presses via `tea.KeyMsg`, and assert model state.
+
+### Test Summary
+
+| Test ID | Title | Type | Task | Priority |
+|---------|-------|------|------|----------|
+| UT-TUI-026 | Enter commits enum field and returns to Browsing | Unit | Task 2 | P0 |
+| UT-TUI-027 | Enter commits string field and returns to Browsing | Unit | Task 2 | P0 |
+| UT-TUI-028 | Enter commits bool field and returns to Browsing | Unit | Task 2 | P0 |
+| UT-TUI-029 | Enter on list field stays in Editing | Unit | Task 2 | P0 |
+| UT-TUI-030 | Modified flag default and after UpdateItemValue | Unit | Task 3 | P0 |
+| UT-TUI-031 | renderItem appends (not-saved) when Modified | Unit | Task 4 | P0 |
+| UT-TUI-032 | ClearAllModified resets all Modified flags | Unit | Task 3 | P0 |
+| UT-TUI-033 | Saved flag cleared after commit | Unit | Task 1/6 | P0 |
+| UT-TUI-034 | Help bar shows enter confirm for non-list editing | Unit | Task 9 | P1 |
+| UT-TUI-035 | Help bar omits enter confirm for list editing | Unit | Task 9 | P1 |
+| UT-TUI-008+ | Extended: Esc commit clears saved and marks Modified | Unit | Task 1/3/6 | P0 |
+| UT-TUI-036 | CurrentFieldType accessor returns correct type | Unit | Task 8 | P1 |
+| UT-TUI-037 | CurrentFieldType returns empty string for nil field | Unit | Task 8 | P1 |
+| UT-TUI-038 | (not-saved) not shown when Modified is false | Unit | Task 4 | P1 |
+| UT-TUI-039 | Narrow terminal with (not-saved) does not panic | Unit | Task 4 | P1 |
+| UT-TUI-040 | Post-save reload preserves cursor by field name | Unit | Task 5 | P0 |
+| UT-TUI-041 | Modified flags cleared after successful save | Unit | Task 7 | P0 |
+| UT-TUI-042 | Save failure does not clear Modified flags | Unit | Task 7 | P1 |
+
+---
+
+## Test UT-TUI-026: Enter commits enum field and returns to Browsing
+
+- **Type:** Unit
+- **Task:** Task 2
+- **Priority:** P0
+
+### Setup
+
+1. Create `config.NewConfig()` with `cfg.Set("model", "gpt-4")`
+2. Define schema with one enum field: `{Name: "model", Type: "enum", Options: ["gpt-4", "gpt-3.5-turbo"]}`
+3. Create model via `NewModel(cfg, schema, "0.0.412", "/tmp/config.json")`
+4. Set `model.windowWidth = 100`, `model.windowHeight = 30`, call `model.updateSizes()`
+5. Transition to editing: send `tea.KeyMsg{Type: tea.KeyEnter}` to enter editing mode
+
+### Steps
+
+1. Verify `model.state == StateEditing`
+2. Send `tea.KeyMsg{Type: tea.KeyEnter}` (Enter key while editing enum field)
+3. Inspect the returned model
+
+### Expected Result
+
+- `m.state == StateBrowsing` — returned to browsing
+- `m.cfg.Get("model")` reflects the committed value
+- `m.listPanel.SelectedItem().Value` matches the committed value
+
+---
+
+## Test UT-TUI-027: Enter commits string field and returns to Browsing
+
+- **Type:** Unit
+- **Task:** Task 2
+- **Priority:** P0
+
+### Setup
+
+1. Create `config.NewConfig()` with `cfg.Set("theme", "dark")`
+2. Define schema with one string field: `{Name: "theme", Type: "string", Default: ""}`
+3. Create model, set window size, and enter editing mode on the "theme" field
+
+### Steps
+
+1. Verify `model.state == StateEditing`
+2. Send `tea.KeyMsg{Type: tea.KeyEnter}`
+3. Inspect the returned model
+
+### Expected Result
+
+- `m.state == StateBrowsing`
+- The string value is committed to `m.cfg`
+
+---
+
+## Test UT-TUI-028: Enter commits bool field and returns to Browsing
+
+- **Type:** Unit
+- **Task:** Task 2
+- **Priority:** P0
+
+### Setup
+
+1. Create `config.NewConfig()` with `cfg.Set("stream", true)`
+2. Define schema with one bool field: `{Name: "stream", Type: "bool", Default: "true"}`
+3. Create model, set window size, and enter editing mode
+
+### Steps
+
+1. Verify `model.state == StateEditing`
+2. Optionally toggle the bool (send space key)
+3. Send `tea.KeyMsg{Type: tea.KeyEnter}`
+4. Inspect the returned model
+
+### Expected Result
+
+- `m.state == StateBrowsing`
+- `m.cfg.Get("stream")` reflects the (possibly toggled) bool value
+
+---
+
+## Test UT-TUI-029: Enter on list field stays in Editing
+
+- **Type:** Unit
+- **Task:** Task 2
+- **Priority:** P0
+
+### Setup
+
+1. Create `config.NewConfig()` with `cfg.Set("allowed_urls", []any{"https://example.com"})`
+2. Define schema with one list field: `{Name: "allowed_urls", Type: "list"}`
+3. Create model, set window size, and enter editing mode
+
+### Steps
+
+1. Verify `model.state == StateEditing`
+2. Verify `model.detailPanel.CurrentFieldType() == "list"`
+3. Send `tea.KeyMsg{Type: tea.KeyEnter}`
+4. Inspect the returned model
+
+### Expected Result
+
+- `m.state == StateEditing` — Enter was forwarded to textarea (inserts newline), does NOT exit editing
+- The model is still in editing mode with the detail panel active
+
+---
+
+## Test UT-TUI-030: Modified flag default and after UpdateItemValue
+
+- **Type:** Unit
+- **Task:** Task 3
+- **Priority:** P0
+
+### Setup
+
+1. Create list entries via `buildEntries()` with a sample schema
+2. Create `NewListPanel(entries)`
+
+### Steps
+
+1. Iterate all entries and check `item.Modified` is `false`
+2. Call `lp.UpdateItemValue("field_name", "new_value")`
+3. Find the entry with `Field.Name == "field_name"` and check `item.Modified`
+
+### Expected Result
+
+- All entries initially have `Modified == false`
+- After `UpdateItemValue`, the matching entry has `Modified == true`
+- Non-matching entries still have `Modified == false`
+
+---
+
+## Test UT-TUI-031: renderItem appends (not-saved) when Modified is true
+
+- **Type:** Unit
+- **Task:** Task 4
+- **Priority:** P0
+
+### Setup
+
+1. Create a `ListPanel` with entries
+2. Set panel width (e.g., `lp.SetSize(60, 20)`)
+3. Call `lp.UpdateItemValue("field_name", "new_value")` to set `Modified = true`
+
+### Steps
+
+1. Call `lp.View()` to render the list
+2. Inspect the rendered output for the modified field
+
+### Expected Result
+
+- The rendered line for the modified field contains the substring `(not-saved)`
+- The rendered line for unmodified fields does NOT contain `(not-saved)`
+
+---
+
+## Test UT-TUI-032: ClearAllModified resets all Modified flags
+
+- **Type:** Unit
+- **Task:** Task 3
+- **Priority:** P0
+
+### Setup
+
+1. Create a `ListPanel` with multiple entries
+2. Call `UpdateItemValue` on two or more entries to set `Modified = true`
+
+### Steps
+
+1. Verify at least two entries have `Modified == true`
+2. Call `lp.ClearAllModified()`
+3. Iterate all entries and check `Modified`
+
+### Expected Result
+
+- After `ClearAllModified()`, all entries have `Modified == false`
+
+---
+
+## Test UT-TUI-033: Saved flag cleared after commit
+
+- **Type:** Unit
+- **Task:** Task 1, Task 6
+- **Priority:** P0
+
+### Setup
+
+1. Create model with a non-sensitive field
+2. Set `model.saved = true` (simulating a prior Ctrl+S)
+3. Enter editing mode
+
+### Steps
+
+1. **Sub-test A (Esc commit):** Send `tea.KeyMsg{Type: tea.KeyEsc}` → verify `m.saved == false`
+2. **Sub-test B (Enter commit on non-list):** Set `model.saved = true` again, enter editing mode, send `tea.KeyMsg{Type: tea.KeyEnter}` → verify `m.saved == false`
+
+### Expected Result
+
+- In both sub-tests, `m.saved == false` after the commit
+- `m.err == nil` after the commit
+- `m.state == StateBrowsing` after the commit
+
+---
+
+## Test UT-TUI-034: Help bar shows enter confirm for non-list editing
+
+- **Type:** Unit
+- **Task:** Task 9
+- **Priority:** P1
+
+### Setup
+
+1. Create `DefaultKeyMap()`
+2. Optionally: create a model with a string/enum/bool field in editing state
+
+### Steps
+
+1. Call `keys.ShortHelp(StateEditing, "string")` (or equivalent field-type-aware call)
+2. Inspect the returned key bindings
+
+### Expected Result
+
+- The returned bindings include a binding with help key `"enter"` and help desc containing `"confirm"`
+- The returned bindings also include the `Escape` binding
+
+---
+
+## Test UT-TUI-035: Help bar omits enter confirm for list editing
+
+- **Type:** Unit
+- **Task:** Task 9
+- **Priority:** P1
+
+### Setup
+
+1. Create `DefaultKeyMap()`
+
+### Steps
+
+1. Call `keys.ShortHelp(StateEditing, "list")` (or equivalent field-type-aware call)
+2. Inspect the returned key bindings
+
+### Expected Result
+
+- The returned bindings do NOT include a binding with help key `"enter"` and help desc `"confirm"`
+- The returned bindings include the `Escape` binding with `"done"` description
+- The returned bindings include `Save` and `Quit`
+
+---
+
+## Test UT-TUI-008+ (Extended): Esc commit clears saved and marks Modified
+
+- **Type:** Unit (extension of existing)
+- **Task:** Task 1, Task 3, Task 6
+- **Priority:** P0
+
+### Setup
+
+Same as existing UT-TUI-008:
+1. Create model with enum field, set `model.state = StateEditing`
+2. Additionally set `model.saved = true` before the Esc
+
+### Steps
+
+1. Send `tea.KeyMsg{Type: tea.KeyEsc}`
+2. Check `m.state`, `m.saved`, and the selected item's `Modified` flag
+
+### Expected Result
+
+- `m.state == StateBrowsing` (existing assertion)
+- `m.saved == false` (new assertion — stale banner cleared)
+- The committed field's `Modified` flag is `true` in the list panel entry (new assertion — dirty tracking)
+
+---
+
+## Test UT-TUI-036: CurrentFieldType accessor returns correct type
+
+- **Type:** Unit
+- **Task:** Task 8
+- **Priority:** P1
+
+### Setup
+
+1. Create a `DetailPanel` via `NewDetailPanel()`
+
+### Steps
+
+1. Call `dp.SetField(field, value)` for each type: `"string"`, `"bool"`, `"enum"`, `"list"`
+2. After each `SetField`, call `dp.CurrentFieldType()`
+
+### Expected Result
+
+- Returns `"string"` after setting a string field
+- Returns `"bool"` after setting a bool field
+- Returns `"enum"` after setting an enum field
+- Returns `"list"` after setting a list field
+
+---
+
+## Test UT-TUI-037: CurrentFieldType returns empty string for nil field
+
+- **Type:** Unit
+- **Task:** Task 8
+- **Priority:** P1
+
+### Setup
+
+1. Create a `DetailPanel` via `NewDetailPanel()` — do NOT call `SetField()`
+
+### Steps
+
+1. Call `dp.CurrentFieldType()`
+
+### Expected Result
+
+- Returns `""` (empty string)
+
+---
+
+## Test UT-TUI-038: (not-saved) not shown when Modified is false
+
+- **Type:** Unit
+- **Task:** Task 4
+- **Priority:** P1
+
+### Setup
+
+1. Create a `ListPanel` with entries (do NOT call `UpdateItemValue`)
+2. Set panel size
+
+### Steps
+
+1. Call `lp.View()` to render the list
+
+### Expected Result
+
+- No line in the rendered output contains the substring `(not-saved)`
+
+---
+
+## Test UT-TUI-039: Narrow terminal with (not-saved) does not panic
+
+- **Type:** Unit
+- **Task:** Task 4
+- **Priority:** P1
+
+### Setup
+
+1. Create a `ListPanel` with entries
+2. Set panel width to narrow value: `lp.SetSize(30, 10)`
+3. Call `UpdateItemValue` to set `Modified = true` on one entry
+
+### Steps
+
+1. Call `lp.View()` — must not panic
+
+### Expected Result
+
+- Function returns a non-empty string without panicking
+- The `(not-saved)` suffix may be truncated at narrow widths but the rendering is safe
+
+---
+
+## Test UT-TUI-040: Post-save reload preserves cursor by field name
+
+- **Type:** Unit
+- **Task:** Task 5
+- **Priority:** P0
+
+### Setup
+
+1. Create a model with multiple fields
+2. Navigate cursor to a field that is NOT the first entry (e.g., second or third field)
+3. Record the selected field name
+4. Write config to a temp file so `SaveConfig` + `LoadConfig` round-trip works
+
+### Steps
+
+1. Send `tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("s")}` with `Alt: true` — or directly call the ctrl+s handler
+2. After save+reload, check the selected item's field name
+
+### Expected Result
+
+- `m.listPanel.SelectedItem().Field.Name` matches the field name from before the save
+- `m.saved == true`
+- `m.err == nil`
+
+---
+
+## Test UT-TUI-041: Modified flags cleared after successful save
+
+- **Type:** Unit
+- **Task:** Task 7
+- **Priority:** P0
+
+### Setup
+
+1. Create a model with a field
+2. Enter editing, commit a change (so the field is marked `Modified`)
+3. Write config to a temp file
+
+### Steps
+
+1. Trigger `ctrl+s` save
+2. Iterate all list entries and check `Modified`
+
+### Expected Result
+
+- All entries have `Modified == false` after the save
+- `m.saved == true`
+- No `(not-saved)` text appears in `lp.View()`
+
+---
+
+## Test UT-TUI-042: Save failure does not clear Modified flags
+
+- **Type:** Unit
+- **Task:** Task 7
+- **Priority:** P1
+
+### Setup
+
+1. Create a model with `configPath` pointing to an invalid/unwritable path (e.g., `/nonexistent/path/config.json`)
+2. Mark a field as modified by committing a change
+
+### Steps
+
+1. Trigger `ctrl+s` save (which will fail because the path is unwritable)
+2. Check the field's `Modified` flag
+
+### Expected Result
+
+- `m.err != nil` (save failed)
+- `m.saved == false` (save did not succeed)
+- The modified field still has `Modified == true`
+
+---
+
+## Regression Tests
+
+All 25 existing tests (UT-TUI-001 through UT-TUI-025) must continue to pass unchanged. The following are particularly relevant for regression:
+
+| Test ID | Risk | Why |
+|---------|------|-----|
+| UT-TUI-007 | Enter in Browsing → Editing transition | Must not be affected by Enter-commit logic (that only applies in StateEditing) |
+| UT-TUI-008 | Esc in Editing → Browsing transition | Core commit path is being refactored into helper; must still work |
+| UT-TUI-012 | formatValueCompact correctness | Adding `(not-saved)` suffix must not break the base formatting function |
+| UT-TUI-018 | View at 80x24 | `(not-saved)` suffix must not cause overflow at standard terminal size |
+
+## Execution
+
+```bash
+# Run all TUI tests
+go test ./internal/tui/... -v
+
+# Run only new tests (by name pattern)
+go test ./internal/tui/... -v -run "TestEnter|TestModified|TestClearAll|TestSaved|TestHelp|TestCurrentFieldType|TestNotSaved|TestNarrow|TestPostSave"
+
+# Run with race detector
+go test ./internal/tui/... -race -v
+```

--- a/docs/workitems/WI-0006-user-experience-saving/implementation/README.md
+++ b/docs/workitems/WI-0006-user-experience-saving/implementation/README.md
@@ -1,0 +1,227 @@
+# Implementation Notes: WI-0006 — User Experience Saving
+
+## Task 8: Expose CurrentFieldType accessor on DetailPanel
+
+- **Status:** Complete
+- **Files Changed:** `internal/tui/detail_panel.go`, `internal/tui/tui_test.go`
+- **Tests Passed:** 32
+- **Tests Failed:** 0
+
+### Changes Summary
+
+Added `CurrentFieldType() string` method to `DetailPanel` in `detail_panel.go`. The method returns `d.field.Type` when a field is loaded, or `""` when `d.field` is nil. Placed after `SetSize()` method and before `View()`.
+
+### Test Results
+
+- UT-TUI-036 (CurrentFieldType accessor returns correct type): PASS — tests all four types (string, bool, enum, list)
+- UT-TUI-037 (CurrentFieldType returns empty string for nil field): PASS
+
+### Notes
+
+This is a prerequisite for Task 2 (Enter intercept) and Task 9 (context-aware help bar).
+
+---
+
+## Task 3: Add dirty tracking to ConfigItem and ListPanel
+
+- **Status:** Complete
+- **Files Changed:** `internal/tui/list_item.go`, `internal/tui/tui_test.go`
+- **Tests Passed:** 32
+- **Tests Failed:** 0
+
+### Changes Summary
+
+1. Added `Modified bool` field to `ConfigItem` struct
+2. Modified `UpdateItemValue()` to set `Modified = true` on the matching entry
+3. Added `ClearAllModified()` method to `ListPanel` that resets all `Modified` flags
+
+### Test Results
+
+- UT-TUI-030 (Modified flag default and after UpdateItemValue): PASS
+- UT-TUI-032 (ClearAllModified resets all Modified flags): PASS
+- All 25 existing tests continue to pass (no regression)
+
+### Notes
+
+`Modified` defaults to `false` (Go zero value) so existing code that creates `ConfigItem` structs without setting `Modified` behaves correctly.
+
+---
+
+## Task 4: Render "(not-saved)" indicator in list items
+
+- **Status:** Complete
+- **Files Changed:** `internal/tui/list_item.go`, `internal/tui/tui_test.go`
+- **Tests Passed:** 32
+- **Tests Failed:** 0
+
+### Changes Summary
+
+Modified `renderItem()` in `list_item.go` to:
+1. Reduce `valWidth` by 12 when `item.Modified` is true to make room for the " (not-saved)" suffix
+2. Append " (not-saved)" to the value string when `item.Modified` is true
+3. The suffix is only added for non-sensitive fields (sensitive fields show 🔒 regardless)
+4. The `valWidth` floor of 3 prevents negative widths on narrow terminals
+
+### Test Results
+
+- UT-TUI-031 (renderItem appends (not-saved) when Modified): PASS
+- UT-TUI-038 ((not-saved) not shown when Modified is false): PASS
+- UT-TUI-039 (Narrow terminal with (not-saved) does not panic): PASS
+- UT-TUI-018 (View at 80x24 regression): PASS
+
+### Notes
+
+At very narrow widths (< 30), the "(not-saved)" suffix may be truncated by the existing line-truncation logic (`line[:l.width-3] + "…"`), which is safe and expected behavior.
+
+---
+
+## Task 1 + Task 6: Extract commitAndReturnToBrowsing helper + clear saved flag
+
+- **Status:** Complete
+- **Files Changed:** `internal/tui/model.go`, `internal/tui/tui_test.go`
+- **Tests Passed:** 40
+- **Tests Failed:** 0
+
+### Changes Summary
+
+Extracted the inline Esc commit logic from `handleKeyPress` into a new `commitAndReturnToBrowsing()` method on `*Model`. The method:
+1. Calls `m.detailPanel.StopEditing()` to get the new value
+2. Gets the selected item and updates config + list panel
+3. Sets `m.saved = false` (clears stale "✓ Saved" banner — Task 6)
+4. Sets `m.err = nil` (clears stale errors)
+5. Sets `m.state = StateBrowsing`
+
+### Test Results
+
+- UT-TUI-008 (existing Esc transition): PASS (regression)
+- UT-TUI-033 (Saved flag cleared after commit — both Esc and Enter sub-tests): PASS
+
+### Notes
+
+Task 6 is logically integrated into Task 1. The `m.saved = false` line ensures the "✓ Saved" banner disappears when a new edit is committed.
+
+---
+
+## Task 2: Intercept Enter in StateEditing for non-list fields
+
+- **Status:** Complete
+- **Files Changed:** `internal/tui/model.go`, `internal/tui/tui_test.go`
+- **Tests Passed:** 40
+- **Tests Failed:** 0
+
+### Changes Summary
+
+Updated the `StateEditing` case in `handleKeyPress` to handle both Esc and Enter (for non-list fields) as commit triggers:
+```go
+if k == "esc" || (k == "enter" && m.detailPanel.CurrentFieldType() != "list") {
+    m.commitAndReturnToBrowsing()
+    return m, nil
+}
+```
+
+- For `string`, `bool`, `enum` fields: Enter commits and returns to browsing
+- For `list` fields: Enter is forwarded to textarea (inserts newline)
+- Esc always commits and returns to browsing (all field types)
+
+### Test Results
+
+- UT-TUI-026 (Enter commits enum field): PASS
+- UT-TUI-027 (Enter commits string field): PASS
+- UT-TUI-028 (Enter commits bool field): PASS
+- UT-TUI-029 (Enter on list field stays in Editing): PASS
+
+### Notes
+
+Uses `m.detailPanel.CurrentFieldType()` (from Task 8) to determine field type.
+
+---
+
+## Task 5 + Task 7: Post-save reload from disk + clear modified flags
+
+- **Status:** Complete
+- **Files Changed:** `internal/tui/model.go`, `internal/tui/tui_test.go`
+- **Tests Passed:** 40
+- **Tests Failed:** 0
+
+### Changes Summary
+
+Updated the `ctrl+s` handler in `handleKeyPress` to:
+1. After successful `SaveConfig`, call `config.LoadConfig` to reload from disk (Task 5)
+2. On successful reload: save cursor position by field name, replace `m.cfg`, rebuild list entries via `buildEntries()`, restore cursor position, sync detail panel
+3. On reload failure: set `m.err` with descriptive message, keep in-memory state
+4. After successful save (regardless of reload result): call `m.listPanel.ClearAllModified()` (Task 7)
+5. On save failure: do NOT clear modified flags
+
+Added three helper methods:
+- `listPanelWidth()` — returns content width for list panel
+- `listPanelHeight()` — returns content height for list panel
+- `selectFieldByName(name string)` — restores cursor to a field by name
+
+Added `"fmt"` to imports for `fmt.Errorf`.
+
+### Test Results
+
+- UT-TUI-040 (Post-save reload preserves cursor by field name): PASS
+- UT-TUI-041 (Modified flags cleared after successful save): PASS
+- UT-TUI-042 (Save failure does not clear Modified flags): PASS
+
+### Notes
+
+The reload-from-disk pattern follows CC-0004 Integration Guidelines: "After `SaveConfig()` succeeds, call `LoadConfig()` and rebuild list entries from the reloaded config to verify the round-trip."
+
+---
+
+## Task 9: Context-aware help bar
+
+- **Status:** Complete
+- **Files Changed:** `internal/tui/keys.go`, `internal/tui/model.go`, `internal/tui/tui_test.go`
+- **Tests Passed:** 40
+- **Tests Failed:** 0
+
+### Changes Summary
+
+1. Added `Confirm key.Binding` to `KeyMap` struct in `keys.go` with help text `"enter" / "confirm"`
+2. Updated `ShortHelp` signature to `ShortHelp(state State, fieldType string)` in `model.go`
+3. In `StateEditing` for non-list fields: returns `[Confirm, Escape, Save, Quit]`
+4. In `StateEditing` for list fields: returns `[Escape, Save, Quit]` (no Enter confirm — Enter inserts newlines)
+5. Updated call site in `View()` to pass `m.detailPanel.CurrentFieldType()`
+
+### Test Results
+
+- UT-TUI-034 (Help bar shows enter confirm for non-list editing): PASS
+- UT-TUI-035 (Help bar omits enter confirm for list editing): PASS
+
+### Notes
+
+The `Confirm` binding uses the same key (`"enter"`) as the `Enter` binding but with different help text (`"confirm"` vs `"edit"`), so the help bar shows the appropriate context.
+
+---
+
+## Task 10: Add remaining unit tests
+
+- **Status:** Complete
+- **Files Changed:** `internal/tui/tui_test.go`
+- **Tests Passed:** 40
+- **Tests Failed:** 0
+
+### Changes Summary
+
+Added 10 new test functions covering all test plan entries not already implemented:
+- UT-TUI-026: `TestEnterCommitsEnumField`
+- UT-TUI-027: `TestEnterCommitsStringField`
+- UT-TUI-028: `TestEnterCommitsBoolField`
+- UT-TUI-029: `TestEnterOnListFieldStaysEditing`
+- UT-TUI-033: `TestSavedFlagClearedAfterCommit` (with Esc and Enter sub-tests)
+- UT-TUI-034: `TestHelpBarEnterConfirmNonList`
+- UT-TUI-035: `TestHelpBarNoEnterConfirmList`
+- UT-TUI-040: `TestPostSaveReloadPreservesCursor`
+- UT-TUI-041: `TestModifiedFlagsClearedAfterSave`
+- UT-TUI-042: `TestSaveFailureKeepsModifiedFlags`
+
+### Test Results
+
+All 40 tests pass (25 existing + 7 from Tasks 3/4/8 + 10 new = 42 test functions, 40 top-level test runs with sub-tests).
+
+### Notes
+
+Tests 040-042 use `t.TempDir()` for temp file round-trip testing. Test 042 uses an unwritable path to verify save failure behavior.

--- a/docs/workitems/WI-0006-user-experience-saving/research/00-research.md
+++ b/docs/workitems/WI-0006-user-experience-saving/research/00-research.md
@@ -1,0 +1,306 @@
+# WI-0006: User Experience — Saving and Viewing Configuration Values
+
+## Status
+
+Draft
+
+## Scope Classification
+
+**Workitem** — This is a focused UX bug-fix and enhancement confined to the TUI layer (`internal/tui/`). It does not introduce a new architecture, does not change the `internal/config/` or `internal/copilot/` packages, and does not require a new ADR. It does, however, necessitate **updating CORE-COMPONENT-0004** to document the "unsaved changes" state concept that this workitem introduces.
+
+---
+
+## Executive Summary
+
+The TUI editing workflow has four distinct UX breakdowns. First, `Enter` in `StateEditing` does not commit the value and return to browsing — it is forwarded verbatim to the widget (inserting a newline in `textarea`, toggling a boolean, or doing nothing for enums), so users who press `Enter` to confirm a change see no feedback and their change is never committed to the in-memory config. Second, there is no visual "(not-saved)" indicator in the left-panel list to communicate that an in-memory change has not yet been persisted to disk. Third, after `Ctrl+S` saves to disk the model does not re-read the file, so the persisted state is never round-trip–verified in the UI. Fourth, the `saved` flag is never cleared when a new unsaved change is made, causing the "✓ Saved" banner to show stale information.
+
+These four issues are all confined to `internal/tui/` and are correctable with targeted changes to `model.go`, `detail_panel.go`, and `list_item.go`.
+
+---
+
+## 1. Current Implementation Analysis
+
+### 1.1 State Machine
+
+The TUI runs a two-state machine defined in `internal/tui/state.go`[^1]:
+
+```
+StateBrowsing  ──Enter──▶  StateEditing
+StateEditing   ──Esc────▶  StateBrowsing
+(both states)  ──Ctrl+S──▶ (save, stay in same state)
+(both states)  ──Ctrl+C──▶ tea.Quit
+```
+
+`StateSaving` and `StateExiting` are declared but never used[^1].
+
+### 1.2 The Enter-Key Problem (Root Cause)
+
+In `handleKeyPress` (`internal/tui/model.go:166–218`)[^2], the `StateEditing` branch is:
+
+```go
+case StateEditing:
+    if k == "esc" {
+        newValue := m.detailPanel.StopEditing()
+        if item := m.listPanel.SelectedItem(); item != nil {
+            m.cfg.Set(item.Field.Name, newValue)
+            m.listPanel.UpdateItemValue(item.Field.Name, newValue)
+        }
+        m.state = StateBrowsing
+        return m, nil
+    }
+    // All other keys go to detail panel
+    return m, m.detailPanel.Update(msg)   // ← Enter falls here
+```
+
+When the user presses `Enter`, it is forwarded to `detailPanel.Update()`[^3], which:
+
+| Field type | What `Enter` does |
+|------------|-------------------|
+| `bool`     | Toggles the boolean value (`detail_panel.go:157`) — but does **not** commit or exit |
+| `enum`     | Not handled — `Enter` is silently ignored (`detail_panel.go:162–173`) |
+| `string`   | Passed to `textinput.Update()` — textinput does nothing with Enter by default |
+| `list`     | Passed to `textarea.Update()` — inserts a newline (correct for multi-line, but never commits) |
+
+**Consequence**: For `bool`, `enum`, and `string` types, pressing `Enter` feels like it should commit the change but no commit occurs. The user is silently stuck in `StateEditing`. The in-memory value in `cfg` is never updated via `cfg.Set()`, so navigating away shows the old value.
+
+### 1.3 Value Sync After Esc (Working, but Invisible)
+
+When the user does press `Esc`, the flow works correctly[^2]:
+
+```go
+newValue := m.detailPanel.StopEditing()          // extract widget value
+m.cfg.Set(item.Field.Name, newValue)              // update in-memory config
+m.listPanel.UpdateItemValue(item.Field.Name, newValue)  // update list display
+m.state = StateBrowsing
+```
+
+`UpdateItemValue` iterates `l.entries` and mutates the matching entry's `Value`[^4]. The list will render the new value on the next `View()` call. **This path works**, but is only reachable via `Esc`, not `Enter`.
+
+### 1.4 No "Unsaved" State
+
+The `Model` struct has a single `saved bool` field[^5]:
+
+```go
+type Model struct {
+    ...
+    saved bool    // set to true by Ctrl+S; never cleared
+}
+```
+
+This is rendered in the header as `"✓ Saved"` when `m.saved == true`[^6]. There is no concept of "changes exist in memory that have not been persisted". The `saved` flag is never reset when a new edit is committed via `Esc`, so the header can show `"✓ Saved"` even after additional unsaved changes.
+
+There is also no per-item "dirty" marker. `listEntry` holds `item ConfigItem` with `Value any` — no `modified bool`, no `originalValue any`[^4]. The list `formatValueCompact` function has no "(not-saved)" code path[^7].
+
+### 1.5 No Post-Save Reload
+
+The `Ctrl+S` save handler[^2]:
+
+```go
+if k == "ctrl+s" {
+    if err := config.SaveConfig(m.configPath, m.cfg); err != nil {
+        m.err = err
+    } else {
+        m.saved = true
+    }
+    return m, nil
+}
+```
+
+`SaveConfig` writes `m.cfg.data` to disk[^8]. After this, `m.cfg` is **not** reloaded from disk. The in-memory `cfg` continues to be the source of truth. This means:
+
+- Round-trip integrity is not verified (e.g., a partial write would not surface in the UI)
+- If the file is externally modified between load and save, those external changes are silently overwritten without the user knowing
+- The UI doesn't reflect the actual persisted state; it reflects the in-memory state that was written
+
+### 1.6 `SelectedItem()` Returns a Copy
+
+`ListPanel.SelectedItem()` returns a pointer to a stack-allocated copy[^4]:
+
+```go
+func (l *ListPanel) SelectedItem() *ConfigItem {
+    item := l.entries[l.cursor].item   // copy
+    return &item                        // pointer to copy
+}
+```
+
+This is safe for the current read-only usage (`item.Field.Name`, `item.Value`), but must not be relied upon for mutation. `UpdateItemValue` correctly uses a name-based scan to mutate entries in-place.
+
+---
+
+## 2. Gap Analysis
+
+| # | Desired Behaviour | Current Behaviour | Gap |
+|---|-------------------|-------------------|-----|
+| G1 | `Enter` on a config item enters editing mode | ✅ Works — `StateBrowsing` + `Enter` → `StateEditing` | No gap |
+| G2 | `Enter` while editing commits the change and returns to the list | ❌ `Enter` is forwarded to widget; no commit; no state transition | `Enter` must trigger the same `StopEditing` + `cfg.Set` + `UpdateItemValue` flow that `Esc` currently triggers |
+| G3 | List shows "(not-saved)" indicator for changed-but-not-persisted items | ❌ No dirty state exists anywhere | Need dirty tracking per field; `formatValueCompact` must render the indicator |
+| G4 | `Ctrl+S` removes "(not-saved)" indicators | ❌ No dirty state to clear | After successful save, clear dirty markers |
+| G5 | After `Ctrl+S`, the config file is re-read so the UI reflects persisted state | ❌ No reload; in-memory state continues unchanged | Call `config.LoadConfig` after `SaveConfig`; rebuild list entries or sync values |
+| G6 | "✓ Saved" banner disappears when a new unsaved change is made | ❌ `saved` flag is never cleared | Clear `m.saved` (and set dirty marker) when `cfg.Set` is called |
+
+### 2.1 `list` Type Edge Case
+
+For `list`-type fields, `Enter` inside `textarea` is the correct UX for adding a new line. Treating `Enter` as "commit and exit" for `list` fields would make it impossible to enter multi-item lists. The resolution for `list` fields should use a **different commit key**: `Esc` (existing), possibly also `Ctrl+Enter` or a dedicated "Done" help-bar item. This is a known UX asymmetry that the implementer must handle explicitly per field type.
+
+---
+
+## 3. Proposed Approach
+
+### 3.1 Commit on Enter (Fix G2)
+
+In `handleKeyPress`, within `StateEditing`, intercept `Enter` **before** forwarding to the detail panel, but only for field types where `Enter` is unambiguous (i.e., not `list`):
+
+```
+StateEditing + Enter:
+  if field.Type != "list" → commitAndReturnToBrowsing()
+  else                    → forward to detail panel (textarea newline)
+```
+
+`commitAndReturnToBrowsing()` is the same three-step sequence currently used by `Esc`:
+1. `newValue := m.detailPanel.StopEditing()`
+2. `m.cfg.Set(field.Name, newValue)`
+3. `m.listPanel.UpdateItemValue(field.Name, newValue)`
+4. `m.state = StateBrowsing`
+5. Mark field as dirty (see §3.2)
+6. Clear `m.saved`
+
+For `list` fields, `Esc` remains the commit key and should be surfaced in the help bar.
+
+### 3.2 Dirty Tracking (Fix G3, G4, G6)
+
+Introduce a minimal dirty-state mechanism. There are two design options:
+
+**Option A — Dirty set on `Model`**
+Add `dirtyFields map[string]bool` to `Model`. When `cfg.Set` is called for a field, add `fieldName → true`. When `Ctrl+S` succeeds, clear the map.
+
+**Option B — `modified bool` on `ConfigItem`**
+Add `Modified bool` to `ConfigItem` in `list_item.go`. `UpdateItemValue` sets it to `true`. After a successful save, iterate all entries and reset `Modified = false`.
+
+Option A is simpler (no struct change to `ConfigItem`). Option B makes the dirty state co-located with the item, which simplifies rendering. **Option B is recommended** because `renderItem` and `formatValueCompact` operate on `ConfigItem` directly, and co-location avoids a secondary map lookup at render time.
+
+**`formatValueCompact` change (list_item.go)**:
+```go
+// After computing `s`:
+if item.Modified {
+    return s + " (not-saved)"  // or truncate to fit maxLen
+}
+```
+
+The `(not-saved)` suffix must be taken into account when computing `maxLen` to avoid truncating the actual value. The implementer should reduce `valWidth` by `len(" (not-saved)")` (12 chars) whenever any item in the panel is potentially dirty, or truncate intelligently.
+
+### 3.3 Post-Save Reload (Fix G5)
+
+After a successful `config.SaveConfig`, call `config.LoadConfig(m.configPath)` to re-read the persisted file. Then:
+
+1. Replace `m.cfg` with the freshly loaded config
+2. Rebuild the list entries by calling `buildEntries(m.cfg, m.schema)`
+3. Restore the cursor to the same field name (not the same index, since order could theoretically change)
+4. Re-sync the detail panel
+
+This ensures the UI is an accurate reflection of what is on disk. The reload is a file read + JSON unmarshal and is fast enough to be synchronous (no `tea.Cmd` needed).
+
+**Failure path**: if `LoadConfig` fails after a successful `SaveConfig`, show a non-fatal error in the header (using the existing `m.err` field) and keep the in-memory state. This is an edge case (e.g., file permissions changed after save) and should not be silent.
+
+### 3.4 Clear `saved` on New Edit (Fix G6)
+
+When `cfg.Set` is called (i.e., inside `commitAndReturnToBrowsing` and the `Esc` path), set `m.saved = false`. The "✓ Saved" banner will only show immediately after a successful `Ctrl+S` and will disappear the moment the user commits a new change.
+
+### 3.5 Help Bar Update
+
+The help bar in `StateEditing` must reflect the new commit key. Concretely:
+- For non-`list` fields: `enter • confirm` should appear alongside `esc • cancel/confirm`
+- For `list` fields: help should read `esc • done` (Enter = newline is implicit)
+
+This requires a field-type-aware `ShortHelp()` or passing the current field type to `ShortHelp()`. The simplest approach is adding a `currentFieldType string` accessor to `DetailPanel` and using it in `Model.View()` when constructing the help keys.
+
+---
+
+## 4. Files to Be Changed
+
+| File | Change |
+|------|--------|
+| `internal/tui/model.go` | (1) Intercept `Enter` in `StateEditing` for non-`list` fields; (2) reload from disk after `Ctrl+S`; (3) clear `m.saved` on new commit |
+| `internal/tui/list_item.go` | (4) Add `Modified bool` to `ConfigItem`; (5) `UpdateItemValue` sets `Modified = true`; (6) `formatValueCompact` appends `(not-saved)` when `Modified`; (7) new `ClearModified()` method |
+| `internal/tui/detail_panel.go` | (8) Expose `CurrentFieldType() string` accessor for help-bar rendering |
+| `internal/tui/keys.go` | (9) Add `Confirm key.Binding` for Enter-to-commit; update `ShortHelp` to be field-type-aware |
+| `internal/tui/tui_test.go` | (10) Add/update tests for all four fixed behaviours |
+
+No changes are required to `internal/config/`, `internal/copilot/`, `internal/sensitive/`, or `cmd/`.
+
+---
+
+## 5. ADRs and Core-Components
+
+### ADRs
+
+No new ADR is needed. All changes are within the existing two-panel layout pattern established by ADR-0003[^9]. The state machine gains a new transition (`Enter` → commit) but the overall Browsing/Editing duality is unchanged.
+
+### Core-Components
+
+**CORE-COMPONENT-0004 (Configuration Management)** should be **updated** to document:
+
+1. The concept of "unsaved changes" (in-memory `cfg` vs. persisted disk state)
+2. The rule that the UI must re-read the config from disk after each successful save to maintain round-trip integrity
+3. The `Modified` dirty marker on `ConfigItem` as the mechanism for surfacing the "unsaved" state to the user
+
+No new core-component is needed — this is an extension of the existing configuration management contract.
+
+---
+
+## 6. Dependencies and Risks
+
+### Dependencies
+
+- No new Go module dependencies are required. All needed packages (`bubbles/textinput`, `bubbles/textarea`, `lipgloss`, `bubbletea`) are already in `go.mod`.
+- `config.LoadConfig` is already implemented and tested[^8].
+
+### Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Cursor position lost after post-save reload | Medium | Low UX annoyance | Restore cursor by field name after rebuilding entries |
+| `(not-saved)` suffix causes truncation of long values in narrow terminals | Medium | Cosmetic | Compute `valWidth` accounting for the suffix; test at 80-column |
+| `Enter` inside `textarea` (list type) is ambiguous | High | Medium | Explicitly skip Enter-commit for `list` type; document in help bar |
+| Post-save reload fails (race / permissions) | Low | Medium | Non-fatal error in header; keep in-memory state |
+| `saved` true + unsaved changes at same time | Low (fixed) | Medium | Cleared by clearing `m.saved` on every `cfg.Set` call |
+| Existing test UT-TUI-008 ("Esc saves value") may overlap with new Enter behaviour | Certain | Low | Update test to cover both `Enter` and `Esc` commit paths |
+
+---
+
+## 7. Scope Boundary
+
+This workitem is **NOT** proposing:
+
+- Validation before commit (e.g., URL format, enum membership) — that is a separate concern
+- Auto-save on navigation — explicit save gesture (Ctrl+S) is retained as the persistence trigger
+- Undo / revert-to-saved — out of scope
+- Changes to the `list` field multi-line editing UX beyond the `Esc`-to-commit clarification
+- Any change to `internal/config/`, `internal/copilot/`, or the CLI bootstrap in `cmd/`
+
+---
+
+## Confidence Assessment
+
+| Finding | Confidence | Basis |
+|---------|-----------|-------|
+| `Enter` in `StateEditing` does not exit editing | **High** | Direct code trace in `model.go:202–214`[^2] |
+| `Esc` path correctly updates list and in-memory config | **High** | Direct code trace in `model.go:203–210`[^2]; `UpdateItemValue` verified in `list_item.go:78–85`[^4] |
+| No dirty/unsaved state exists | **High** | `Model` struct has only `saved bool`; `ConfigItem` has no `Modified` field[^4][^5] |
+| No post-save disk reload | **High** | `Ctrl+S` handler ends at `m.saved = true`; no `LoadConfig` call[^2] |
+| `saved` flag never cleared on new edit | **High** | No `m.saved = false` assignment anywhere in `model.go`[^2] |
+| Post-save reload is safe to do synchronously | **Medium** | Config file is small JSON; `LoadConfig` is a simple `os.ReadFile` + `json.Unmarshal`[^8]; no observed latency concerns, but not benchmarked |
+| Option B (dirty bit on `ConfigItem`) is preferred | **Medium** | Architectural preference based on co-location principle; implementer may choose Option A |
+
+---
+
+## Footnotes
+
+[^1]: `internal/tui/state.go` — `State` enum with `StateBrowsing`, `StateEditing`, `StateSaving`, `StateExiting`
+[^2]: `internal/tui/model.go:166–218` — `handleKeyPress` function; save handler at lines 174–184; `StateEditing` branch at lines 202–214
+[^3]: `internal/tui/detail_panel.go:149–184` — `DetailPanel.Update()` handling `bool` (toggle on Enter), `enum` (up/down only), `string`/`list` (forwarded to Bubbles widgets)
+[^4]: `internal/tui/list_item.go:12–85` — `ConfigItem`, `listEntry`, `ListPanel` types; `SelectedItem()` returns copy at line 71–75; `UpdateItemValue()` at lines 78–85
+[^5]: `internal/tui/model.go:17–32` — `Model` struct definition; `saved bool` field at line 31
+[^6]: `internal/tui/model.go:283–285` — `View()` rendering `"✓ Saved"` when `m.saved`
+[^7]: `internal/tui/list_item.go:176–211` — `formatValueCompact` function; no dirty/modified code path
+[^8]: `internal/config/config.go` — `LoadConfig` and `SaveConfig` functions
+[^9]: `docs/architecture/ADR/ADR-0003-two-panel-tui-layout.md` — Two-Panel TUI Layout Pattern ADR

--- a/internal/tui/detail_panel.go
+++ b/internal/tui/detail_panel.go
@@ -193,6 +193,14 @@ d.textArea.SetWidth(width - 4)
 }
 }
 
+// CurrentFieldType returns the type of the currently loaded field, or "" if none.
+func (d *DetailPanel) CurrentFieldType() string {
+	if d.field == nil {
+		return ""
+	}
+	return d.field.Type
+}
+
 // View renders the detail panel content (no border — the caller applies the border).
 func (d *DetailPanel) View() string {
 if d.field == nil {

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -4,15 +4,16 @@ import "github.com/charmbracelet/bubbles/key"
 
 // KeyMap defines the key bindings for the TUI.
 type KeyMap struct {
-Up     key.Binding
-Down   key.Binding
-Left   key.Binding
-Right  key.Binding
-Enter  key.Binding
-Escape key.Binding
-Save   key.Binding
-Quit   key.Binding
-Tab    key.Binding
+Up      key.Binding
+Down    key.Binding
+Left    key.Binding
+Right   key.Binding
+Enter   key.Binding
+Confirm key.Binding
+Escape  key.Binding
+Save    key.Binding
+Quit    key.Binding
+Tab     key.Binding
 }
 
 // DefaultKeyMap returns the default key bindings.
@@ -37,6 +38,10 @@ key.WithHelp("→/l", "env vars"),
 Enter: key.NewBinding(
 key.WithKeys("enter"),
 key.WithHelp("enter", "edit"),
+),
+Confirm: key.NewBinding(
+key.WithKeys("enter"),
+key.WithHelp("enter", "confirm"),
 ),
 Escape: key.NewBinding(
 key.WithKeys("esc"),

--- a/internal/tui/list_item.go
+++ b/internal/tui/list_item.go
@@ -10,8 +10,9 @@ import (
 
 // ConfigItem represents a config field in the list.
 type ConfigItem struct {
-Field copilot.SchemaField
-Value any
+Field    copilot.SchemaField
+Value    any
+Modified bool
 }
 
 type listEntry struct {
@@ -79,9 +80,17 @@ func (l *ListPanel) UpdateItemValue(fieldName string, newValue any) {
 for i, e := range l.entries {
 if !e.isHeader && e.item.Field.Name == fieldName {
 l.entries[i].item.Value = newValue
+l.entries[i].item.Modified = true
 break
 }
 }
+}
+
+// ClearAllModified resets the Modified flag on all entries.
+func (l *ListPanel) ClearAllModified() {
+	for i := range l.entries {
+		l.entries[i].item.Modified = false
+	}
 }
 
 func (l *ListPanel) ensureVisible() {
@@ -153,10 +162,16 @@ if isSens || isToken {
 val = "🔒"
 } else {
 valWidth := l.width - nameWidth - 4
+if item.Modified {
+valWidth -= 12 // room for " (not-saved)"
+}
 if valWidth < 3 {
 valWidth = 3
 }
 val = formatValueCompact(item.Value, item.Field.Default, valWidth)
+if item.Modified {
+val += " (not-saved)"
+}
 }
 
 line := fmt.Sprintf("%-*s %s", nameWidth, name, val)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+"fmt"
 "log/slog"
 "sort"
 "strings"
@@ -181,14 +182,7 @@ switch m.state {
 case StateBrowsing:
 switch k {
 case "ctrl+s":
-slog.Info("saving config", "path", m.configPath)
-if err := config.SaveConfig(m.configPath, m.cfg); err != nil {
-m.err = err
-slog.Error("save failed", "error", err)
-} else {
-m.saved = true
-slog.Info("config saved")
-}
+m.saveConfig()
 case "up", "k":
 m.listPanel.Up()
 m.syncDetailPanel()
@@ -208,23 +202,17 @@ slog.Info("switched to env vars view")
 case StateEditing:
 switch k {
 case "ctrl+s":
-slog.Info("saving config", "path", m.configPath)
-if err := config.SaveConfig(m.configPath, m.cfg); err != nil {
-m.err = err
-slog.Error("save failed", "error", err)
-} else {
-m.saved = true
-slog.Info("config saved")
-}
+m.saveConfig()
 case "esc":
-newValue := m.detailPanel.StopEditing()
-if item := m.listPanel.SelectedItem(); item != nil {
-slog.Info("field updated", "field", item.Field.Name)
-m.cfg.Set(item.Field.Name, newValue)
-m.listPanel.UpdateItemValue(item.Field.Name, newValue)
-}
-m.state = StateBrowsing
+m.commitAndReturnToBrowsing()
 return m, nil
+case "enter":
+if m.detailPanel.CurrentFieldType() != "list" {
+m.commitAndReturnToBrowsing()
+return m, nil
+}
+// For list fields, fall through to detail panel
+return m, m.detailPanel.Update(msg)
 default:
 // All other keys go to detail panel
 return m, m.detailPanel.Update(msg)
@@ -247,6 +235,98 @@ return m, nil
 func (m *Model) syncDetailPanel() {
 if item := m.listPanel.SelectedItem(); item != nil {
 m.detailPanel.SetField(item.Field, item.Value)
+}
+}
+
+// commitAndReturnToBrowsing stops editing, commits the value, and returns to browsing.
+func (m *Model) commitAndReturnToBrowsing() {
+newValue := m.detailPanel.StopEditing()
+if item := m.listPanel.SelectedItem(); item != nil {
+slog.Info("field updated", "field", item.Field.Name)
+m.cfg.Set(item.Field.Name, newValue)
+m.listPanel.UpdateItemValue(item.Field.Name, newValue)
+}
+m.saved = false
+m.err = nil
+m.state = StateBrowsing
+m.syncDetailPanel()
+}
+
+// saveConfig persists config to disk, reloads to verify round-trip, and clears modified flags.
+func (m *Model) saveConfig() {
+slog.Info("saving config", "path", m.configPath)
+if err := config.SaveConfig(m.configPath, m.cfg); err != nil {
+m.err = err
+slog.Error("save failed", "error", err)
+return
+}
+m.saved = true
+m.err = nil
+slog.Info("config saved")
+
+// Post-save reload from disk
+reloaded, err := config.LoadConfig(m.configPath)
+if err != nil {
+m.err = fmt.Errorf("saved but reload failed: %w", err)
+slog.Error("post-save reload failed", "error", err)
+} else {
+// Save cursor position by field name
+var cursorFieldName string
+if item := m.listPanel.SelectedItem(); item != nil {
+cursorFieldName = item.Field.Name
+}
+
+// Replace config and rebuild entries
+m.cfg = reloaded
+entries := buildEntries(m.cfg, m.schema)
+m.listPanel = NewListPanel(entries)
+m.listPanel.SetSize(m.listPanelWidth(), m.listPanelHeight())
+
+// Restore cursor to same field name
+if cursorFieldName != "" {
+m.selectFieldByName(cursorFieldName)
+}
+
+m.syncDetailPanel()
+}
+
+// Clear modified flags
+m.listPanel.ClearAllModified()
+}
+
+// listPanelWidth returns the content width of the list panel.
+func (m *Model) listPanelWidth() int {
+innerWidth := m.windowWidth - 2
+leftWidth := int(float64(innerWidth) * 0.40)
+w := leftWidth - 4
+if w < 1 {
+w = 1
+}
+return w
+}
+
+// listPanelHeight returns the content height of the list panel.
+func (m *Model) listPanelHeight() int {
+innerHeight := m.windowHeight - 2
+panelHeight := innerHeight - 10
+if panelHeight < 3 {
+panelHeight = 3
+}
+h := panelHeight - 2
+if h < 1 {
+h = 1
+}
+return h
+}
+
+// selectFieldByName moves the cursor to the entry with the given field name.
+func (m *Model) selectFieldByName(name string) {
+for i, e := range m.listPanel.entries {
+if !e.isHeader && e.item.Field.Name == name {
+m.listPanel.cursor = i
+m.listPanel.ensureVisible()
+return
+}
 }
 }
 
@@ -362,7 +442,8 @@ panels = lipgloss.JoinHorizontal(lipgloss.Top, leftPanel, " ", rightPanel)
 }
 
 // Help bar
-helpKeys := m.keys.ShortHelp(m.state)
+fieldType := m.detailPanel.CurrentFieldType()
+helpKeys := m.keys.ShortHelp(m.state, fieldType)
 var parts []string
 for _, kb := range helpKeys {
 h := kb.Help()
@@ -383,11 +464,14 @@ Render(inner)
 }
 
 // ShortHelp returns bindings for the help bar based on current state.
-func (k KeyMap) ShortHelp(state State) []key.Binding {
+func (k KeyMap) ShortHelp(state State, fieldType string) []key.Binding {
 switch state {
 case StateBrowsing:
 return []key.Binding{k.Up, k.Down, k.Enter, k.Right, k.Tab, k.Save, k.Quit}
 case StateEditing:
+if fieldType != "list" {
+return []key.Binding{k.Confirm, k.Escape, k.Save, k.Quit}
+}
 return []key.Binding{k.Escape, k.Save, k.Quit}
 case StateEnvVars:
 return []key.Binding{k.Up, k.Down, k.Left, k.Tab, k.Quit}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,6 +1,8 @@
 package tui
 
 import (
+"os"
+"path/filepath"
 "strings"
 "testing"
 
@@ -1075,7 +1077,7 @@ func TestViewInEnvVarsState(t *testing.T) {
 // UT-TUI-051: ShortHelp for StateBrowsing includes right/tab binding
 func TestShortHelpBrowsingIncludesRight(t *testing.T) {
 	km := DefaultKeyMap()
-	bindings := km.ShortHelp(StateBrowsing)
+	bindings := km.ShortHelp(StateBrowsing, "")
 	found := false
 	for _, b := range bindings {
 		if b.Help().Desc == "env vars" {
@@ -1091,7 +1093,7 @@ func TestShortHelpBrowsingIncludesRight(t *testing.T) {
 // UT-TUI-052: ShortHelp for StateEnvVars includes left/tab and omits enter/save
 func TestShortHelpEnvVarsBindings(t *testing.T) {
 	km := DefaultKeyMap()
-	bindings := km.ShortHelp(StateEnvVars)
+	bindings := km.ShortHelp(StateEnvVars, "")
 	var foundConfig, foundEdit, foundSave bool
 	for _, b := range bindings {
 		desc := b.Help().Desc
@@ -1119,7 +1121,7 @@ func TestShortHelpEnvVarsBindings(t *testing.T) {
 // UT-TUI-053: ShortHelp for StateEditing remains unchanged
 func TestShortHelpEditingUnchanged(t *testing.T) {
 	km := DefaultKeyMap()
-	bindings := km.ShortHelp(StateEditing)
+	bindings := km.ShortHelp(StateEditing, "")
 	descs := make(map[string]bool)
 	for _, b := range bindings {
 		descs[b.Help().Desc] = true
@@ -1148,4 +1150,533 @@ func TestNewModelNilEnvVars(t *testing.T) {
 	if model.envPanel == nil {
 		t.Fatal("NewModel with nil envVars should still create envPanel")
 	}
+}
+
+// UT-TUI-055: Enter commits enum field and returns to Browsing
+func TestEnterCommitsEnumField(t *testing.T) {
+cfg := config.NewConfig()
+cfg.Set("model", "gpt-4")
+
+schema := []copilot.SchemaField{
+{Name: "model", Type: "enum", Default: "gpt-4", Options: []string{"gpt-4", "gpt-3.5-turbo"}},
+}
+
+model := NewModel(cfg, schema, nil, "0.0.412", "/tmp/config.json")
+model.windowWidth = 100
+model.windowHeight = 30
+model.updateSizes()
+
+// Enter editing
+newModel, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m := newModel.(*Model)
+if m.state != StateEditing {
+t.Fatal("Expected StateEditing after Enter")
+}
+
+// Press Enter to commit (enum field, not list)
+newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m = newModel.(*Model)
+if m.state != StateBrowsing {
+t.Errorf("Expected StateBrowsing after Enter on enum field, got %v", m.state)
+}
+}
+
+// UT-TUI-056: Enter commits string field and returns to Browsing
+func TestEnterCommitsStringField(t *testing.T) {
+cfg := config.NewConfig()
+cfg.Set("theme", "dark")
+
+schema := []copilot.SchemaField{
+{Name: "theme", Type: "string", Default: ""},
+}
+
+model := NewModel(cfg, schema, nil, "0.0.412", "/tmp/config.json")
+model.windowWidth = 100
+model.windowHeight = 30
+model.updateSizes()
+
+// Enter editing
+newModel, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m := newModel.(*Model)
+if m.state != StateEditing {
+t.Fatal("Expected StateEditing after Enter")
+}
+
+// Press Enter to commit (string field)
+newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m = newModel.(*Model)
+if m.state != StateBrowsing {
+t.Errorf("Expected StateBrowsing after Enter on string field, got %v", m.state)
+}
+}
+
+// UT-TUI-057: Enter commits bool field and returns to Browsing
+func TestEnterCommitsBoolField(t *testing.T) {
+cfg := config.NewConfig()
+cfg.Set("stream", true)
+
+schema := []copilot.SchemaField{
+{Name: "stream", Type: "bool", Default: "true"},
+}
+
+model := NewModel(cfg, schema, nil, "0.0.412", "/tmp/config.json")
+model.windowWidth = 100
+model.windowHeight = 30
+model.updateSizes()
+
+// Enter editing
+newModel, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m := newModel.(*Model)
+if m.state != StateEditing {
+t.Fatal("Expected StateEditing after Enter")
+}
+
+// Press Enter to commit (bool field)
+newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m = newModel.(*Model)
+if m.state != StateBrowsing {
+t.Errorf("Expected StateBrowsing after Enter on bool field, got %v", m.state)
+}
+}
+
+// UT-TUI-058: Enter on list field stays in Editing
+func TestEnterOnListFieldStaysEditing(t *testing.T) {
+cfg := config.NewConfig()
+cfg.Set("allowed_urls", []any{"https://example.com"})
+
+schema := []copilot.SchemaField{
+{Name: "allowed_urls", Type: "list"},
+}
+
+model := NewModel(cfg, schema, nil, "0.0.412", "/tmp/config.json")
+model.windowWidth = 100
+model.windowHeight = 30
+model.updateSizes()
+
+// Enter editing
+newModel, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m := newModel.(*Model)
+if m.state != StateEditing {
+t.Fatal("Expected StateEditing after Enter")
+}
+
+// Press Enter on list field — should stay in editing (newline in textarea)
+newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m = newModel.(*Model)
+if m.state != StateEditing {
+t.Errorf("Expected to remain in StateEditing for list field, got %v", m.state)
+}
+}
+
+// UT-TUI-059: Modified flag default and after UpdateItemValue
+func TestModifiedFlagDefaultAndAfterUpdate(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Set("model", "gpt-4")
+	cfg.Set("theme", "dark")
+
+	schema := []copilot.SchemaField{
+		{Name: "model", Type: "enum", Default: "gpt-4", Options: []string{"gpt-4", "gpt-3.5-turbo"}},
+		{Name: "theme", Type: "string", Default: "auto"},
+	}
+
+	entries := buildEntries(cfg, schema)
+	lp := NewListPanel(entries)
+
+	for _, e := range lp.entries {
+		if !e.isHeader && e.item.Modified {
+			t.Errorf("Entry %q should have Modified == false initially", e.item.Field.Name)
+		}
+	}
+
+	lp.UpdateItemValue("model", "gpt-3.5-turbo")
+
+	for _, e := range lp.entries {
+		if !e.isHeader && e.item.Field.Name == "model" {
+			if !e.item.Modified {
+				t.Error("Entry 'model' should have Modified == true after UpdateItemValue")
+			}
+		}
+		if !e.isHeader && e.item.Field.Name == "theme" {
+			if e.item.Modified {
+				t.Error("Entry 'theme' should still have Modified == false")
+			}
+		}
+	}
+}
+
+// UT-TUI-060: renderItem appends (not-saved) when Modified is true
+func TestRenderItemNotSavedIndicator(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Set("model", "gpt-4")
+	cfg.Set("theme", "dark")
+
+	schema := []copilot.SchemaField{
+		{Name: "model", Type: "enum", Default: "gpt-4", Options: []string{"gpt-4", "gpt-3.5-turbo"}},
+		{Name: "theme", Type: "string", Default: "auto"},
+	}
+
+	entries := buildEntries(cfg, schema)
+	lp := NewListPanel(entries)
+	lp.SetSize(60, 20)
+
+	lp.UpdateItemValue("model", "gpt-3.5-turbo")
+
+	view := lp.View()
+
+	if !strings.Contains(view, "(not-saved)") {
+		t.Error("Expected '(not-saved)' indicator in rendered output for modified field")
+	}
+
+	lines := strings.Split(view, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "theme") && strings.Contains(line, "(not-saved)") {
+			t.Error("Unmodified field 'theme' should NOT have '(not-saved)' indicator")
+		}
+	}
+}
+
+// UT-TUI-061: ClearAllModified resets all Modified flags
+func TestClearAllModified(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Set("model", "gpt-4")
+	cfg.Set("theme", "dark")
+
+	schema := []copilot.SchemaField{
+		{Name: "model", Type: "enum", Default: "gpt-4", Options: []string{"gpt-4", "gpt-3.5-turbo"}},
+		{Name: "theme", Type: "string", Default: "auto"},
+	}
+
+	entries := buildEntries(cfg, schema)
+	lp := NewListPanel(entries)
+
+	lp.UpdateItemValue("model", "gpt-3.5-turbo")
+	lp.UpdateItemValue("theme", "light")
+
+	modCount := 0
+	for _, e := range lp.entries {
+		if !e.isHeader && e.item.Modified {
+			modCount++
+		}
+	}
+	if modCount < 2 {
+		t.Fatalf("Expected at least 2 modified entries, got %d", modCount)
+	}
+
+	lp.ClearAllModified()
+
+	for _, e := range lp.entries {
+		if !e.isHeader && e.item.Modified {
+			t.Errorf("Entry %q should have Modified == false after ClearAllModified", e.item.Field.Name)
+		}
+	}
+}
+
+// UT-TUI-062: Saved flag cleared after commit
+func TestSavedFlagClearedAfterCommit(t *testing.T) {
+cfg := config.NewConfig()
+cfg.Set("model", "gpt-4")
+
+schema := []copilot.SchemaField{
+{Name: "model", Type: "enum", Default: "gpt-4", Options: []string{"gpt-4", "gpt-3.5-turbo"}},
+}
+
+t.Run("Esc commit clears saved", func(t *testing.T) {
+model := NewModel(cfg, schema, nil, "0.0.412", "/tmp/config.json")
+model.windowWidth = 100
+model.windowHeight = 30
+model.updateSizes()
+model.saved = true
+
+newModel, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m := newModel.(*Model)
+
+newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+m = newModel.(*Model)
+if m.saved {
+t.Error("saved should be false after Esc commit")
+}
+if m.state != StateBrowsing {
+t.Error("should be in StateBrowsing after Esc")
+}
+})
+
+t.Run("Enter commit clears saved", func(t *testing.T) {
+model := NewModel(cfg, schema, nil, "0.0.412", "/tmp/config.json")
+model.windowWidth = 100
+model.windowHeight = 30
+model.updateSizes()
+model.saved = true
+
+newModel, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m := newModel.(*Model)
+
+newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m = newModel.(*Model)
+if m.saved {
+t.Error("saved should be false after Enter commit")
+}
+if m.state != StateBrowsing {
+t.Error("should be in StateBrowsing after Enter")
+}
+})
+}
+
+// UT-TUI-063: Help bar shows enter confirm for non-list editing
+func TestHelpBarEnterConfirmNonList(t *testing.T) {
+keys := DefaultKeyMap()
+bindings := keys.ShortHelp(StateEditing, "string")
+
+found := false
+for _, b := range bindings {
+h := b.Help()
+if h.Key == "enter" && strings.Contains(h.Desc, "confirm") {
+found = true
+}
+}
+if !found {
+t.Error("Expected 'enter' + 'confirm' binding in editing help for non-list field")
+}
+}
+
+// UT-TUI-064: Help bar omits enter confirm for list editing
+func TestHelpBarNoEnterConfirmList(t *testing.T) {
+keys := DefaultKeyMap()
+bindings := keys.ShortHelp(StateEditing, "list")
+
+for _, b := range bindings {
+h := b.Help()
+if h.Key == "enter" && strings.Contains(h.Desc, "confirm") {
+t.Error("List editing should NOT show 'enter confirm' binding")
+}
+}
+}
+
+// UT-TUI-065: CurrentFieldType accessor returns correct type
+func TestCurrentFieldType(t *testing.T) {
+	dp := NewDetailPanel()
+	dp.SetSize(50, 20)
+
+	tests := []struct {
+		name     string
+		field    copilot.SchemaField
+		value    any
+		wantType string
+	}{
+		{"string", copilot.SchemaField{Name: "theme", Type: "string", Default: ""}, "dark", "string"},
+		{"bool", copilot.SchemaField{Name: "stream", Type: "bool", Default: "true"}, true, "bool"},
+		{"enum", copilot.SchemaField{Name: "model", Type: "enum", Default: "gpt-4", Options: []string{"gpt-4", "gpt-3.5-turbo"}}, "gpt-4", "enum"},
+		{"list", copilot.SchemaField{Name: "allowed_urls", Type: "list"}, []any{"https://example.com"}, "list"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dp.SetField(tt.field, tt.value)
+			got := dp.CurrentFieldType()
+			if got != tt.wantType {
+				t.Errorf("CurrentFieldType() = %q, want %q", got, tt.wantType)
+			}
+		})
+	}
+}
+
+// UT-TUI-066: CurrentFieldType returns empty string for nil field
+func TestCurrentFieldTypeNilField(t *testing.T) {
+	dp := NewDetailPanel()
+	got := dp.CurrentFieldType()
+	if got != "" {
+		t.Errorf("CurrentFieldType() on fresh panel = %q, want empty string", got)
+	}
+}
+
+// UT-TUI-067: (not-saved) not shown when Modified is false
+func TestNotSavedNotShownWhenUnmodified(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Set("model", "gpt-4")
+	cfg.Set("theme", "dark")
+
+	schema := []copilot.SchemaField{
+		{Name: "model", Type: "enum", Default: "gpt-4", Options: []string{"gpt-4", "gpt-3.5-turbo"}},
+		{Name: "theme", Type: "string", Default: "auto"},
+	}
+
+	entries := buildEntries(cfg, schema)
+	lp := NewListPanel(entries)
+	lp.SetSize(60, 20)
+
+	view := lp.View()
+
+	if strings.Contains(view, "(not-saved)") {
+		t.Error("No '(not-saved)' indicator should appear when no fields are modified")
+	}
+}
+
+// UT-TUI-068: Narrow terminal with (not-saved) does not panic
+func TestNarrowTerminalNotSavedNoPanic(t *testing.T) {
+	cfg := config.NewConfig()
+	cfg.Set("model", "gpt-4")
+
+	schema := []copilot.SchemaField{
+		{Name: "model", Type: "enum", Default: "gpt-4", Options: []string{"gpt-4", "gpt-3.5-turbo"}},
+	}
+
+	entries := buildEntries(cfg, schema)
+	lp := NewListPanel(entries)
+	lp.SetSize(30, 10)
+
+	lp.UpdateItemValue("model", "gpt-3.5-turbo")
+
+	view := lp.View()
+	if view == "" {
+		t.Error("View() at narrow width returned empty string")
+	}
+}
+
+// UT-TUI-069: Post-save reload preserves cursor by field name
+func TestPostSaveReloadPreservesCursor(t *testing.T) {
+tmpDir := t.TempDir()
+tmpFile := filepath.Join(tmpDir, "config.json")
+
+cfg := config.NewConfig()
+cfg.Set("model", "gpt-4")
+cfg.Set("theme", "dark")
+cfg.Set("stream", true)
+
+schema := []copilot.SchemaField{
+{Name: "model", Type: "enum", Default: "gpt-4", Options: []string{"gpt-4", "gpt-3.5-turbo"}},
+{Name: "stream", Type: "bool", Default: "true"},
+{Name: "theme", Type: "string", Default: "auto"},
+}
+
+if err := config.SaveConfig(tmpFile, cfg); err != nil {
+t.Fatalf("Failed to write initial config: %v", err)
+}
+
+model := NewModel(cfg, schema, nil, "0.0.412", tmpFile)
+model.windowWidth = 100
+model.windowHeight = 30
+model.updateSizes()
+
+model.listPanel.Down()
+selectedBefore := model.listPanel.SelectedItem()
+if selectedBefore == nil {
+t.Fatal("Expected a selected item after Down")
+}
+fieldNameBefore := selectedBefore.Field.Name
+
+newModel, _ := model.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+m := newModel.(*Model)
+
+if !m.saved {
+t.Error("Expected saved == true after Ctrl+S")
+}
+if m.err != nil {
+t.Errorf("Expected no error after save, got: %v", m.err)
+}
+
+selectedAfter := m.listPanel.SelectedItem()
+if selectedAfter == nil {
+t.Fatal("Expected a selected item after save+reload")
+}
+if selectedAfter.Field.Name != fieldNameBefore {
+t.Errorf("Expected cursor on %q after save+reload, got %q", fieldNameBefore, selectedAfter.Field.Name)
+}
+}
+
+// UT-TUI-070: Modified flags cleared after successful save
+func TestModifiedFlagsClearedAfterSave(t *testing.T) {
+tmpDir := t.TempDir()
+tmpFile := filepath.Join(tmpDir, "config.json")
+
+cfg := config.NewConfig()
+cfg.Set("model", "gpt-4")
+
+schema := []copilot.SchemaField{
+{Name: "model", Type: "enum", Default: "gpt-4", Options: []string{"gpt-4", "gpt-3.5-turbo"}},
+}
+
+if err := config.SaveConfig(tmpFile, cfg); err != nil {
+t.Fatalf("Failed to write initial config: %v", err)
+}
+
+model := NewModel(cfg, schema, nil, "0.0.412", tmpFile)
+model.windowWidth = 100
+model.windowHeight = 30
+model.updateSizes()
+
+newModel, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m := newModel.(*Model)
+newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+m = newModel.(*Model)
+
+hasModified := false
+for _, e := range m.listPanel.entries {
+if !e.isHeader && e.item.Modified {
+hasModified = true
+break
+}
+}
+if !hasModified {
+t.Fatal("Expected at least one modified entry before save")
+}
+
+newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+m = newModel.(*Model)
+
+if !m.saved {
+t.Error("Expected saved == true after Ctrl+S")
+}
+
+for _, e := range m.listPanel.entries {
+if !e.isHeader && e.item.Modified {
+t.Errorf("Entry %q should have Modified == false after save", e.item.Field.Name)
+}
+}
+
+view := m.listPanel.View()
+if strings.Contains(view, "(not-saved)") {
+t.Error("No '(not-saved)' text should appear after successful save")
+}
+}
+
+// UT-TUI-071: Save failure does not clear Modified flags
+func TestSaveFailureKeepsModifiedFlags(t *testing.T) {
+cfg := config.NewConfig()
+cfg.Set("model", "gpt-4")
+
+schema := []copilot.SchemaField{
+{Name: "model", Type: "enum", Default: "gpt-4", Options: []string{"gpt-4", "gpt-3.5-turbo"}},
+}
+
+invalidPath := filepath.Join(string(os.PathSeparator), "nonexistent", "deep", "path", "config.json")
+
+model := NewModel(cfg, schema, nil, "0.0.412", invalidPath)
+model.windowWidth = 100
+model.windowHeight = 30
+model.updateSizes()
+
+newModel, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m := newModel.(*Model)
+newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+m = newModel.(*Model)
+
+newModel, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+m = newModel.(*Model)
+
+if m.err == nil {
+t.Error("Expected error after save to invalid path")
+}
+if m.saved {
+t.Error("Expected saved == false after failed save")
+}
+
+hasModified := false
+for _, e := range m.listPanel.entries {
+if !e.isHeader && e.item.Modified {
+hasModified = true
+break
+}
+}
+if !hasModified {
+t.Error("Modified flags should be preserved when save fails")
+}
 }


### PR DESCRIPTION
## Summary — WI-0006

Improves the TUI config-saving user experience with dirty field tracking, post-save verification, and a more intuitive confirm key binding.

### Changes

**Source (`internal/tui/`)**
- **`model.go`** — Post-save reload from disk to verify round-trip integrity; preserve cursor position across the save-and-reload cycle
- **`list_item.go`** — Add `Modified` flag to `ConfigItem`; show `(not-saved)` indicator next to modified fields in the list panel
- **`detail_panel.go`** — Add Enter key to commit edits on non-list fields (Esc still works)
- **`keys.go`** — Add `Confirm` key binding with field-type-aware help bar text
- **`tui_test.go`** — Add 17 new tests (UT-TUI-055 through UT-TUI-071) covering dirty tracking, reload verification, cursor preservation, and Enter-to-confirm

**Architecture & Documentation**
- **CC-0004** (`CORE-COMPONENT-0004-configuration-management.md`) — Updated with dirty tracking and reload guidance
- **DECISION-LOG.md** — Added decisions 23–25
- **WI-0006** — New work item documentation (action plan, task breakdown, test plan, research, implementation README)

### ADRs / Core-Components Referenced
- `docs/architecture/core-components/CORE-COMPONENT-0004-configuration-management.md` (updated)
- `docs/architecture/ADR/DECISION-LOG.md` (decisions 23–25 added)

### Test Results
All tests pass (`go test ./...` — all green, including 17 new tests)
