### PR TITLE
fix: correct install script archive naming and update WI-0008 docs

### DIFF
--- a/docs/workitems/WI-0008-cicd-pipeline/implementation/README.md
+++ b/docs/workitems/WI-0008-cicd-pipeline/implementation/README.md
@@ -1,5 +1,23 @@
 # WI-0008: CI/CD Pipeline — Implementation Notes
 
+## Post-Implementation Errata
+
+### Workflow Consolidation (release.yml → release-please.yml)
+
+The original plan called for 4 separate workflows including a standalone `release.yml` triggered by `push tags: v*`. This design failed because tags created by release-please using `GITHUB_TOKEN` do not trigger `push` events (GitHub's anti-cascade protection).
+
+**Fix:** The GoReleaser release job was moved into `release-please.yml` as a dependent `goreleaser` job that runs when `release_created == true`. The standalone `release.yml` was deleted. The project now has **3 workflows**: `ci.yml`, `govulncheck.yml`, and `release-please.yml`.
+
+### Install Script Archive Naming
+
+The install script originally used `ccc_<os>_<arch>.tar.gz` (binary name) but GoReleaser's `{{ .ProjectName }}` resolves to `co-config` (the Go module name), producing `co-config_<os>_<arch>.tar.gz`. The script was updated to use `PROJECT_NAME="co-config"` for archive naming.
+
+### Action Org Migration
+
+`google-github-actions/release-please-action` is archived. The canonical repo is `googleapis/release-please-action`. All references updated.
+
+---
+
 ## Task 1.1: Create `.golangci.yml` Linter Configuration
 
 - **Status:** Complete

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,7 @@ set -e
 # ── Constants ────────────────────────────────────────────────────────────────
 
 REPO="jsburckhardt/co-config"
+PROJECT_NAME="co-config"
 BINARY_NAME="ccc"
 GITHUB_API="https://api.github.com/repos/${REPO}/releases"
 GITHUB_DOWNLOAD="https://github.com/${REPO}/releases/download"
@@ -106,7 +107,7 @@ resolve_version() {
 # ── Download & Verify ────────────────────────────────────────────────────────
 
 download_and_verify() {
-  ARCHIVE_NAME="${BINARY_NAME}_${OS}_${ARCH}.tar.gz"
+  ARCHIVE_NAME="${PROJECT_NAME}_${OS}_${ARCH}.tar.gz"
   CHECKSUMS_NAME="checksums.txt"
   DOWNLOAD_BASE="${GITHUB_DOWNLOAD}/${VERSION}"
 


### PR DESCRIPTION
**Two fixes:**

1. **Install script 404:** `install.sh` used `ccc_linux_amd64.tar.gz` but GoReleaser produces `co-config_linux_amd64.tar.gz` (uses `ProjectName` from module). Added `PROJECT_NAME` variable and use it for archive URLs.

2. **WI-0008 docs errata:** Added post-implementation notes covering the 3 deviations from the original plan: workflow consolidation, archive naming, and action org migration.

Workitem: WI-0008-cicd-pipeline